### PR TITLE
Bundle and dlls rename

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -265,3 +265,6 @@ __pycache__/
 
 # CircleCI local testing
 process.yml
+GltfInstaller/glTFExporter.exe
+
+GltfInstaller/wix/GltfInstaller.g.wxs

--- a/Common_glTF_Exporter/Common_glTF_Exporter.projitems
+++ b/Common_glTF_Exporter/Common_glTF_Exporter.projitems
@@ -95,6 +95,7 @@
     <Content Include="$(MSBuildThisFileDirectory)Images\logo.png">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </Content>
+    <Content Include="$(MSBuildThisFileDirectory)PackageContents.xml" />
     <Resource Include="$(MSBuildThisFileDirectory)Fonts\NeuzeitGrotesk-Black.ttf">
       <CopyToOutputDirectory>Never</CopyToOutputDirectory>
     </Resource>
@@ -110,7 +111,7 @@
     <Content Include="$(MSBuildThisFileDirectory)Images\gltf.png">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </Content>
-    <Content Include="$(MSBuildThisFileDirectory)Revit_glTF_Exporter.addin">
+    <Content Include="$(MSBuildThisFileDirectory)Leia_glTF_Exporter.addin">
       <CopyToOutputDirectory>Never</CopyToOutputDirectory>
     </Content>
   </ItemGroup>

--- a/Common_glTF_Exporter/Leia_glTF_Exporter.addin
+++ b/Common_glTF_Exporter/Leia_glTF_Exporter.addin
@@ -1,11 +1,11 @@
 ﻿<?xml version="1.0" encoding="utf-8" standalone="no"?>
 <RevitAddIns>
 	<AddIn Type="Application">
-		<Name>Revit_glTF_Exporter</Name>
-		<Assembly>gltfExporter\Revit_glTF_Exporter.dll</Assembly>
+		<Name>Leia_glTF_Exporter</Name>
+		<Assembly>Leia_glTF_Exporter.dll</Assembly>
 		<FullClassName>Revit_glTF_Exporter.ExternalApplication</FullClassName>
-		<Text>Revit_glTF_Exporter</Text>
-		<Description>Revit_glTF_Exporter</Description>
+		<Text>Leia_glTF_Exporter</Text>
+		<Description>Leia glTF Exporter</Description>
 		<VisibilityMode>AlwaysVisible</VisibilityMode>
 		<AddInId>
 			3c679028-b7ed-4cd7-9307-0e9760e7ea8f

--- a/Common_glTF_Exporter/PackageContents.xml
+++ b/Common_glTF_Exporter/PackageContents.xml
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="utf-8"?>
+<ApplicationPackage SchemaVersion="1.0"
+	ProductType="Application"
+	Name="Leia_glTF_Exporter"
+	AppVersion="1.0.0"
+    Description="Leia glTF Exporter"
+    SupportedLocales="Enu"
+    Author="e-verse"
+    AutodeskProduct="Revit"
+    FriendlyVersion="1.0.0"
+    AppNameSpace="appstore.exchange.autodesk.com">
+
+    <CompanyDetails Name="Leia" />
+
+    <RuntimeRequirements OS="Win32|Win64" Platform="Revit" SeriesMin="R2020" SeriesMax="R2020" />
+
+    <Components Description="2020 parts">
+        <RuntimeRequirements OS="Win64" Platform="Revit" SeriesMin="R2020" SeriesMax="R2020" />
+        <ComponentEntry AppName="Leia_glTF_Exporter" Version="1.0.0" ModuleName="./Contents/2020/Leia_glTF_Exporter.addin" AppDescription="Leia glTF Exporter Add-in" />
+    </Components>
+
+    <Components Description="2021 parts">
+        <RuntimeRequirements OS="Win64" Platform="Revit" SeriesMin="R2021" SeriesMax="R2021" />
+        <ComponentEntry AppName="Leia_glTF_Exporter" Version="1.0.0" ModuleName="./Contents/2021/Leia_glTF_Exporter.addin" AppDescription="Leia glTF Exporter Add-in" />
+    </Components>
+
+    <Components Description="2022 parts">
+        <RuntimeRequirements OS="Win64" Platform="Revit" SeriesMin="R2022" SeriesMax="R2022" />
+        <ComponentEntry AppName="Leia_glTF_Exporter" Version="1.0.0" ModuleName="./Contents/2021/Leia_glTF_Exporter.addin" AppDescription="Leia glTF Exporter Add-in" />
+    </Components>
+
+    <Components Description="2023 parts">
+        <RuntimeRequirements OS="Win64" Platform="Revit" SeriesMin="R2023" SeriesMax="R2023" />
+        <ComponentEntry AppName="Leia_glTF_Exporter" Version="1.0.0" ModuleName="./Contents/2023/Leia_glTF_Exporter.addin" AppDescription="Leia glTF Exporter Add-in" />
+    </Components>
+
+    <Components Description="2024 parts">
+        <RuntimeRequirements OS="Win64" Platform="Revit" SeriesMin="R2024" SeriesMax="R2024" />
+        <ComponentEntry AppName="Leia_glTF_Exporter" Version="1.0.0" ModuleName="./Contents/2024/Leia_glTF_Exporter.addin" AppDescription="Leia glTF Exporter Add-in" />
+    </Components>
+</ApplicationPackage>

--- a/GltfInstaller/Program.cs
+++ b/GltfInstaller/Program.cs
@@ -12,27 +12,28 @@ namespace GltfInstaller
             //#if REVIT2019 || REVIT2020
 
             var project = new ManagedProject("Leia glTF exporter",
-                              new Dir(@"%AppDataFolder%\Autodesk\Revit\Addins",
-                                  new Dir(@"2019",
-                                    new File(@"..\Common_glTF_Exporter\Revit_glTF_Exporter.addin"),
-                                    new Dir(@"gltfExporter",
-                                        new Files(@"..\Revit_glTF_Exporter_2019\bin\Release\*.*"))),
-                                  new Dir(@"2020",
-                                    new File(@"..\Common_glTF_Exporter\Revit_glTF_Exporter.addin"),
-                                    new Dir(@"gltfExporter",
-                                        new Files(@"..\Revit_glTF_Exporter_2020\bin\Release\*.*"))),
-                                  new Dir(@"2021",
-                                    new File(@"..\Common_glTF_Exporter\Revit_glTF_Exporter.addin"),
-                                    new Dir(@"gltfExporter",
-                                        new Files(@"..\Revit_glTF_Exporter_2021\bin\Release\*.*"))),
-                                  new Dir(@"2022",
-                                    new File(@"..\Common_glTF_Exporter\Revit_glTF_Exporter.addin"),
-                                    new Dir(@"gltfExporter",
-                                        new Files(@"..\Revit_glTF_Exporter_2022\bin\Release\*.*"))),
-                                  new Dir(@"2023",
-                                    new File(@"..\Common_glTF_Exporter\Revit_glTF_Exporter.addin"),
-                                    new Dir(@"gltfExporter",
-                                        new Files(@"..\Revit_glTF_Exporter_2023\bin\Release\*.*"))))
+                              new Dir(@"%AppDataFolder%\Autodesk\ApplicationPlugins",
+                                  new Dir(@"gltfExporter.bundle",
+                                  new File(@"..\Common_glTF_Exporter\PackageContents.xml"),
+                                      new Dir(@"Contents",
+                                        new Dir(@"2019",
+                                            new File(@"..\Common_glTF_Exporter\Leia_glTF_Exporter.addin"),
+                                            new Files(@"..\Revit_glTF_Exporter_2019\bin\Release\*.*")),
+                                        new Dir(@"2020",
+                                            new File(@"..\Common_glTF_Exporter\Leia_glTF_Exporter.addin"),
+                                            new Files(@"..\Revit_glTF_Exporter_2020\bin\Release\*.*")),
+                                        new Dir(@"2021",
+                                            new File(@"..\Common_glTF_Exporter\Leia_glTF_Exporter.addin"),
+                                            new Files(@"..\Revit_glTF_Exporter_2021\bin\Release\*.*")),
+                                        new Dir(@"2022",
+                                            new File(@"..\Common_glTF_Exporter\Leia_glTF_Exporter.addin"),
+                                            new Files(@"..\Revit_glTF_Exporter_2022\bin\Release\*.*")),
+                                        new Dir(@"2023",
+                                            new File(@"..\Common_glTF_Exporter\Leia_glTF_Exporter.addin"),
+                                            new Files(@"..\Revit_glTF_Exporter_2023\bin\Release\*.*")),
+                                        new Dir(@"2024",
+                                            new File(@"..\Common_glTF_Exporter\Leia_glTF_Exporter.addin"),
+                                            new Files(@"..\Revit_glTF_Exporter_2024\bin\Release\*.*")))))
                               );
 
             project.GUID = new Guid("6fe30b47-2577-43ad-9095-1861ba25889b");
@@ -64,12 +65,12 @@ namespace GltfInstaller
                 OutputFile = "glTFExporter.exe",
                 IconFile = "Resources\\logo.ico",
 
-                VersionInfo = new VersionInformation("1.0.0.0")
+                VersionInfo = new VersionInformation("1.1.0.0")
                 {
                     ProductName = "Test Application",
                     LegalCopyright = "Copyright Test company",
                     FileDescription = "Test Application",
-                    FileVersion = "1.0.0",
+                    FileVersion = "1.1.0",
                     CompanyName = "Test company",
                     InternalName = "setup.exe",
                     OriginalFilename = "setup.exe"

--- a/Revit_glTF_Exporter_2019/Revit_glTF_Exporter_2019.csproj
+++ b/Revit_glTF_Exporter_2019/Revit_glTF_Exporter_2019.csproj
@@ -8,7 +8,7 @@
     <OutputType>Library</OutputType>
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Revit_glTF_Exporter</RootNamespace>
-    <AssemblyName>Revit_glTF_Exporter</AssemblyName>
+    <AssemblyName>Leia_glTF_Exporter</AssemblyName>
     <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
     <RuntimeIdentifier>win</RuntimeIdentifier>
     <FileAlignment>512</FileAlignment>

--- a/Revit_glTF_Exporter_2020/Revit_glTF_Exporter_2020.csproj
+++ b/Revit_glTF_Exporter_2020/Revit_glTF_Exporter_2020.csproj
@@ -8,7 +8,7 @@
     <OutputType>Library</OutputType>
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Revit_glTF_Exporter</RootNamespace>
-    <AssemblyName>Revit_glTF_Exporter</AssemblyName>
+    <AssemblyName>Leia_glTF_Exporter</AssemblyName>
     <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
     <RuntimeIdentifier>win</RuntimeIdentifier>
     <FileAlignment>512</FileAlignment>
@@ -24,7 +24,7 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <CodeAnalysisRuleSet>..\Revit_glTF_Exporter_2023\e-verse.ruleset</CodeAnalysisRuleSet>
-    <IntermediateOutputPath>C:\Users\danie\AppData\Local\Temp\vs19DB.tmp\Debug\</IntermediateOutputPath>
+    <IntermediateOutputPath>C:\Users\PabloD\AppData\Local\Temp\vsB300.tmp\Debug\</IntermediateOutputPath>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>
@@ -33,7 +33,7 @@
     <DefineConstants>DEBUG;TRACE;REVIT2020</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
-    <IntermediateOutputPath>C:\Users\danie\AppData\Local\Temp\vs19DB.tmp\Release\</IntermediateOutputPath>
+    <IntermediateOutputPath>C:\Users\PabloD\AppData\Local\Temp\vsB300.tmp\Release\</IntermediateOutputPath>
     <CodeAnalysisRuleSet>..\Revit_glTF_Exporter_2023\e-verse.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'REVIT2019|AnyCPU'">
@@ -45,7 +45,7 @@
     <LangVersion>7.3</LangVersion>
     <ErrorReport>prompt</ErrorReport>
     <CodeAnalysisRuleSet>..\..\..\..\Downloads\e-verse.ruleset</CodeAnalysisRuleSet>
-    <IntermediateOutputPath>C:\Users\danie\AppData\Local\Temp\vs19DB.tmp\REVIT2019\</IntermediateOutputPath>
+    <IntermediateOutputPath>C:\Users\PabloD\AppData\Local\Temp\vsB300.tmp\REVIT2019\</IntermediateOutputPath>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'REVIT2020|AnyCPU'">
     <DebugSymbols>true</DebugSymbols>
@@ -56,7 +56,7 @@
     <LangVersion>7.3</LangVersion>
     <ErrorReport>prompt</ErrorReport>
     <CodeAnalysisRuleSet>..\..\..\..\Downloads\e-verse.ruleset</CodeAnalysisRuleSet>
-    <IntermediateOutputPath>C:\Users\danie\AppData\Local\Temp\vs19DB.tmp\REVIT2020\</IntermediateOutputPath>
+    <IntermediateOutputPath>C:\Users\PabloD\AppData\Local\Temp\vsB300.tmp\REVIT2020\</IntermediateOutputPath>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'REVIT2021|AnyCPU'">
     <DebugSymbols>true</DebugSymbols>
@@ -67,11 +67,11 @@
     <LangVersion>7.3</LangVersion>
     <ErrorReport>prompt</ErrorReport>
     <CodeAnalysisRuleSet>..\..\..\..\Downloads\e-verse.ruleset</CodeAnalysisRuleSet>
-    <IntermediateOutputPath>C:\Users\danie\AppData\Local\Temp\vs19DB.tmp\REVIT2021\</IntermediateOutputPath>
+    <IntermediateOutputPath>C:\Users\PabloD\AppData\Local\Temp\vsB300.tmp\REVIT2021\</IntermediateOutputPath>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'REVIT2022|AnyCPU' ">
     <OutputPath>bin\REVIT20222\</OutputPath>
-    <IntermediateOutputPath>C:\Users\danie\AppData\Local\Temp\vs19DB.tmp\REVIT2022\</IntermediateOutputPath>
+    <IntermediateOutputPath>C:\Users\PabloD\AppData\Local\Temp\vsB300.tmp\REVIT2022\</IntermediateOutputPath>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'REVIT2023|AnyCPU'">
     <DebugSymbols>true</DebugSymbols>
@@ -82,7 +82,7 @@
     <LangVersion>7.3</LangVersion>
     <ErrorReport>prompt</ErrorReport>
     <CodeAnalysisRuleSet>..\..\..\..\Downloads\e-verse.ruleset</CodeAnalysisRuleSet>
-    <IntermediateOutputPath>C:\Users\danie\AppData\Local\Temp\vs19DB.tmp\REVIT2023\</IntermediateOutputPath>
+    <IntermediateOutputPath>C:\Users\PabloD\AppData\Local\Temp\vsB300.tmp\REVIT2023\</IntermediateOutputPath>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="PresentationCore" />

--- a/Revit_glTF_Exporter_2021/Revit_glTF_Exporter_2021.csproj
+++ b/Revit_glTF_Exporter_2021/Revit_glTF_Exporter_2021.csproj
@@ -8,7 +8,7 @@
     <OutputType>Library</OutputType>
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Revit_glTF_Exporter</RootNamespace>
-    <AssemblyName>Revit_glTF_Exporter</AssemblyName>
+    <AssemblyName>Leia_glTF_Exporter</AssemblyName>
     <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
     <RuntimeIdentifier>win</RuntimeIdentifier>
     <FileAlignment>512</FileAlignment>

--- a/Revit_glTF_Exporter_2022/Revit_glTF_Exporter_2022.csproj
+++ b/Revit_glTF_Exporter_2022/Revit_glTF_Exporter_2022.csproj
@@ -8,7 +8,7 @@
     <OutputType>Library</OutputType>
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Revit_glTF_Exporter</RootNamespace>
-    <AssemblyName>Revit_glTF_Exporter</AssemblyName>
+    <AssemblyName>Leia_glTF_Exporter</AssemblyName>
     <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
     <RuntimeIdentifier>win</RuntimeIdentifier>
     <FileAlignment>512</FileAlignment>

--- a/Revit_glTF_Exporter_2023/Revit_glTF_Exporter_2023.csproj
+++ b/Revit_glTF_Exporter_2023/Revit_glTF_Exporter_2023.csproj
@@ -8,7 +8,7 @@
     <OutputType>Library</OutputType>
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Revit_glTF_Exporter</RootNamespace>
-    <AssemblyName>Revit_glTF_Exporter</AssemblyName>
+    <AssemblyName>Leia_glTF_Exporter</AssemblyName>
     <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
     <RuntimeIdentifier>win</RuntimeIdentifier>
     <FileAlignment>512</FileAlignment>

--- a/Revit_glTF_Exporter_2024/Revit_glTF_Exporter_2024.csproj
+++ b/Revit_glTF_Exporter_2024/Revit_glTF_Exporter_2024.csproj
@@ -9,7 +9,7 @@
     <OutputType>Library</OutputType>
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Revit_glTF_Exporter</RootNamespace>
-    <AssemblyName>Revit_glTF_Exporter</AssemblyName>
+    <AssemblyName>Leia_glTF_Exporter</AssemblyName>
     <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <Deterministic>true</Deterministic>


### PR DESCRIPTION
This PR aims to change the location of the addin to a bundle and remove all mention of Revit in the final dlls.