### PR TITLE
Adjusted Loading Bar behaviour

### DIFF
--- a/Common_glTF_Exporter/Core/GlTFExportContext.cs
+++ b/Common_glTF_Exporter/Core/GlTFExportContext.cs
@@ -197,8 +197,6 @@ namespace Revit_glTF_Exporter
                 return RenderNodeAction.Skip;
             }
 
-            linkTransformation = (element as RevitLinkInstance)?.GetTransform();
-
             if (nodes.Contains(element.UniqueId))
             {
                 // Duplicate element, skip adding.
@@ -206,8 +204,16 @@ namespace Revit_glTF_Exporter
                 return RenderNodeAction.Skip;
             }
 
+            linkTransformation = (element as RevitLinkInstance)?.GetTransform();
+
             if (linkTransformation == null)
-                ProgressBarWindow.ViewModel.ProgressBarValue++;
+            {
+                if (!element.IsHidden(view) && 
+                    view.IsElementVisibleInTemporaryViewMode(TemporaryViewMode.TemporaryHideIsolate, elementId))
+                {
+                    ProgressBarWindow.ViewModel.ProgressBarValue++;
+                }
+            }    
 
             // create a new node for the element
             GLTFNode newNode = new GLTFNode();


### PR DESCRIPTION
The loading bar was having odd behavior when there were hidden elements and a link. It seems IExportContext processes also temporary hidden elements, so I adjusted it so those will not be used on the calculation of the loading bar