### PR TITLE
Cu 66ayz543j add textures export

### DIFF
--- a/Common_glTF_Exporter/Common_glTF_Exporter.projitems
+++ b/Common_glTF_Exporter/Common_glTF_Exporter.projitems
@@ -9,6 +9,7 @@
     <Import_RootNamespace>Common_glTF_Exporter</Import_RootNamespace>
   </PropertyGroup>
   <ItemGroup>
+    <Compile Include="$(MSBuildThisFileDirectory)Core\GLTFImage.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Core\GLTFPBR.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Core\GLTFExtras.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Core\GLTFAccessor.cs" />
@@ -20,6 +21,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Core\GLTFMesh.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Core\GLTFNode.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Core\GLTFScene.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Core\GLTFTextureInfo.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Core\GLTFVersion.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Core\GLTFBinaryData.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Core\IndexedDictionary.cs" />

--- a/Common_glTF_Exporter/Common_glTF_Exporter.projitems
+++ b/Common_glTF_Exporter/Common_glTF_Exporter.projitems
@@ -51,6 +51,8 @@
     <Compile Include="$(MSBuildThisFileDirectory)Model\GeometryDataObject.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Model\PointIntObject.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Model\VertexLookupIntObject.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Service\RevitCollectorService.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Service\UIApplicationExtension.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Transform\ModelRotation.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Transform\ModelScale.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Utils\Analytics.cs" />

--- a/Common_glTF_Exporter/Core/GLTFAttribute.cs
+++ b/Common_glTF_Exporter/Core/GLTFAttribute.cs
@@ -1,5 +1,6 @@
 ﻿namespace Common_glTF_Exporter.Core
 {
+    using Newtonsoft.Json;
     using System;
     using System.Collections.Generic;
     using System.Text;
@@ -18,16 +19,19 @@
         /// <summary>
         /// Gets or sets the index of the accessor for normal data.
         /// </summary>
-        public int NORMAL { get; set; }
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public int? NORMAL { get; set; }
 
         /// <summary>
         /// Gets or sets the index of the accessor for batchId data.
         /// </summary>
-        public int _BATCHID { get; set; }
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public int? _BATCHID { get; set; }
 
         /// <summary>
         /// Gets or sets the index of the UV Coordinates of the material's textures.
         /// </summary>
-        public int TEXCOORD_0 { get; set; }
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public int? TEXCOORD_0 { get; set; }
     }
 }

--- a/Common_glTF_Exporter/Core/GLTFAttribute.cs
+++ b/Common_glTF_Exporter/Core/GLTFAttribute.cs
@@ -24,5 +24,10 @@
         /// Gets or sets the index of the accessor for batchId data.
         /// </summary>
         public int _BATCHID { get; set; }
+
+        /// <summary>
+        /// Gets or sets the index of the UV Coordinates of the material's textures.
+        /// </summary>
+        public int TEXCOORD_0 { get; set; }
     }
 }

--- a/Common_glTF_Exporter/Core/GLTFBinaryData.cs
+++ b/Common_glTF_Exporter/Core/GLTFBinaryData.cs
@@ -30,5 +30,7 @@
 
         public List<float> uvBuffer { get; set; } = new List<float>();
         public int uvAccessorIndex { get; set; } = -1;
+
+        public byte[] byteData { get; set; } = null;
     }
 }

--- a/Common_glTF_Exporter/Core/GLTFBinaryData.cs
+++ b/Common_glTF_Exporter/Core/GLTFBinaryData.cs
@@ -27,5 +27,8 @@
         public int batchIdAccessorIndex { get; set; }
 
         public string name { get; set; }
+
+        public List<float> uvBuffer { get; set; } = new List<float>();
+        public int uvAccessorIndex { get; set; } = -1;
     }
 }

--- a/Common_glTF_Exporter/Core/GLTFBufferView.cs
+++ b/Common_glTF_Exporter/Core/GLTFBufferView.cs
@@ -1,10 +1,11 @@
 ﻿namespace Common_glTF_Exporter.Core
 {
+    using Newtonsoft.Json;
     using Revit_glTF_Exporter;
 
     /// <summary>
-    /// A reference to a subsection of a buffer containing either vector or scalar data
-    /// https://github.com/KhronosGroup/glTF/tree/master/specification/2.0#buffers-and-buffer-views.
+    /// A reference to a subsection of a buffer containing either vector or scalar data.
+    /// https://github.com/KhronosGroup/glTF/tree/master/specification/2.0#buffers-and-buffer-views
     /// </summary>
     public class GLTFBufferView
     {
@@ -17,29 +18,38 @@
             this.name = name;
         }
 
-        /// <summary>
-        /// Gets or sets the index of the buffer.
-        /// </summary>
+        [JsonProperty("buffer")]
         public int buffer { get; set; }
 
-        /// <summary>
-        /// Gets or sets the offset into the buffer in bytes.
-        /// </summary>
+        [JsonProperty("byteOffset")]
         public int byteOffset { get; set; }
 
-        /// <summary>
-        /// Gets or sets the length of the bufferView in bytes.
-        /// </summary>
+        [JsonProperty("byteLength")]
         public int byteLength { get; set; }
 
-        /// <summary>
-        /// Gets or sets the target that the GPU buffer should be bound to.
-        /// </summary>
+        [JsonIgnore] // Ignore the raw enum field so we can customize serialization
         public Targets target { get; set; }
 
-        /// <summary>
-        /// Gets or sets a user defined name for this view.
-        /// </summary>
+        [JsonProperty("target")]
+        public int? TargetValue
+        {
+            get
+            {
+                if (target == Targets.ARRAY_BUFFER)
+                    return 34962;
+                else if (target == Targets.ELEMENT_ARRAY_BUFFER)
+                    return 34963;
+                else
+                    return null;
+            }
+        }
+
+        public bool ShouldSerializeTargetValue()
+        {
+            return TargetValue != null;
+        }
+
+        [JsonProperty("name")]
         public string name { get; set; }
     }
 }

--- a/Common_glTF_Exporter/Core/GLTFImage.cs
+++ b/Common_glTF_Exporter/Core/GLTFImage.cs
@@ -1,0 +1,19 @@
+namespace Common_glTF_Exporter.Core
+{
+    /// <summary>
+    /// An image used by a texture
+    /// https://github.com/KhronosGroup/glTF/tree/master/specification/2.0#images
+    /// </summary>
+    public class GLTFImage
+    {
+        /// <summary>
+        /// The uri of the image
+        /// </summary>
+        public string uri { get; set; }
+
+        /// <summary>
+        /// The image's MIME type
+        /// </summary>
+        public string mimeType { get; set; }
+    }
+} 

--- a/Common_glTF_Exporter/Core/GLTFImage.cs
+++ b/Common_glTF_Exporter/Core/GLTFImage.cs
@@ -1,3 +1,5 @@
+using Newtonsoft.Json;
+
 namespace Common_glTF_Exporter.Core
 {
     /// <summary>
@@ -6,14 +8,13 @@ namespace Common_glTF_Exporter.Core
     /// </summary>
     public class GLTFImage
     {
-        /// <summary>
-        /// The uri of the image
-        /// </summary>
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
         public string uri { get; set; }
 
-        /// <summary>
-        /// The image's MIME type
-        /// </summary>
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public int? bufferView { get; set; }
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
         public string mimeType { get; set; }
     }
 } 

--- a/Common_glTF_Exporter/Core/GLTFMaterial.cs
+++ b/Common_glTF_Exporter/Core/GLTFMaterial.cs
@@ -20,5 +20,11 @@
         public GLTFPBR pbrMetallicRoughness { get; set; }
 
         public bool doubleSided { get; set; }
+
+        // Texture properties
+        public GLTFTexture normalTexture { get; set; }
+        public GLTFTexture occlusionTexture { get; set; }
+        public GLTFTexture emissiveTexture { get; set; }
+        public List<float> emissiveFactor { get; set; }
     }
 }

--- a/Common_glTF_Exporter/Core/GLTFMaterial.cs
+++ b/Common_glTF_Exporter/Core/GLTFMaterial.cs
@@ -3,6 +3,7 @@
     using System;
     using System.Collections.Generic;
     using System.Text;
+    using Newtonsoft.Json;
     using Revit_glTF_Exporter;
 
     /// <summary>
@@ -21,10 +22,12 @@
 
         public bool doubleSided { get; set; }
 
-        // Texture properties
         public GLTFTexture normalTexture { get; set; }
         public GLTFTexture occlusionTexture { get; set; }
         public GLTFTexture emissiveTexture { get; set; }
         public List<float> emissiveFactor { get; set; }
+
+        [JsonIgnore]
+        public string EmbeddedTexturePath { get; set; } = null;
     }
 }

--- a/Common_glTF_Exporter/Core/GLTFTextureInfo.cs
+++ b/Common_glTF_Exporter/Core/GLTFTextureInfo.cs
@@ -1,5 +1,6 @@
 namespace Common_glTF_Exporter.Core
 {
+    using Newtonsoft.Json;
     using System;
     using System.Collections.Generic;
 
@@ -16,5 +17,22 @@ namespace Common_glTF_Exporter.Core
     {
         public int index { get; set; }
         public int texCoord { get; set; } = 0;
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public GLTFTextureExtensions extensions { get; set; }
+    }
+
+    public class GLTFTextureTransform
+    {
+        public float[] offset { get; set; } = new float[] { 0.0f, 0.0f };
+        public float[] scale { get; set; } = new float[] { 1.0f, 1.0f };
+        public float rotation { get; set; } = 0.0f;
+        public int texCoord { get; set; } = 0;
+    }
+
+    public class GLTFTextureExtensions
+    {
+        [JsonProperty("KHR_texture_transform")]
+        public GLTFTextureTransform TextureTransform { get; set; }
     }
 } 

--- a/Common_glTF_Exporter/Core/GLTFTextureInfo.cs
+++ b/Common_glTF_Exporter/Core/GLTFTextureInfo.cs
@@ -1,0 +1,20 @@
+namespace Common_glTF_Exporter.Core
+{
+    using System;
+    using System.Collections.Generic;
+
+    /// <summary>
+    /// Texture information for a material property
+    /// https://github.com/KhronosGroup/glTF/tree/master/specification/2.0#texture-info
+    /// </summary>
+    public class GLTFTexture
+    {
+        public int source { get; set; }
+    }
+
+    public class GLTFTextureInfo
+    {
+        public int index { get; set; }
+        public int texCoord { get; set; } = 0;
+    }
+} 

--- a/Common_glTF_Exporter/Core/GlTFExportContext.cs
+++ b/Common_glTF_Exporter/Core/GlTFExportContext.cs
@@ -451,7 +451,7 @@
 
                 primitive.indices = elementBinary.indexAccessorIndex;
 
-                if (preferences.materials == MaterialsEnum.materials)
+                if (preferences.materials == MaterialsEnum.materials || preferences.materials == MaterialsEnum.textures)
                 {
                     if (materials.Contains(material_key))
                     {

--- a/Common_glTF_Exporter/Core/GlTFExportContext.cs
+++ b/Common_glTF_Exporter/Core/GlTFExportContext.cs
@@ -298,7 +298,7 @@
         {
             if (preferences.materials == MaterialsEnum.materials || preferences.materials ==  MaterialsEnum.textures)
             {
-                currentMaterial = RevitMaterials.Export(node, doc, ref materials, preferences);
+                currentMaterial = RevitMaterials.Export(node, ref materials, preferences);
             }
         }
 

--- a/Common_glTF_Exporter/Core/GlTFExportContext.cs
+++ b/Common_glTF_Exporter/Core/GlTFExportContext.cs
@@ -334,7 +334,8 @@
                             if (projection != null)
                             {
                                 UV uv = projection.UVPoint;
-                                currentGeometry.CurrentItem.Uvs.Add(uv);
+                                UV uvInMeters = new UV(uv.U * 12, uv.V * 12);
+                                currentGeometry.CurrentItem.Uvs.Add(uvInMeters);
                             }
                             else
                             {

--- a/Common_glTF_Exporter/Core/GlTFExportContext.cs
+++ b/Common_glTF_Exporter/Core/GlTFExportContext.cs
@@ -201,9 +201,12 @@
                 RevitGrids.Export(doc, ref nodes, ref rootNode, preferences);
             }
 
-            FileExport.Run(preferences, bufferViews, buffers, binaryFileData,
-                scenes, nodes, meshes, materials, accessors, textures, images);
-            Compression.Run(preferences, ProgressBarWindow.ViewModel);
+            if (bufferViews.Count != 0)
+            {
+                FileExport.Run(preferences, bufferViews, buffers, binaryFileData,
+                    scenes, nodes, meshes, materials, accessors, textures, images);
+                Compression.Run(preferences, ProgressBarWindow.ViewModel);
+            }
         }
 
         /// <summary>

--- a/Common_glTF_Exporter/Core/glTF.cs
+++ b/Common_glTF_Exporter/Core/glTF.cs
@@ -35,6 +35,7 @@ namespace Revit_glTF_Exporter
     public struct GLTF
     {
         public GLTFVersion asset;
+        public List<string> extensionsUsed;
         public List<GLTFScene> scenes;
         public List<GLTFNode> nodes;
         public List<GLTFMesh> meshes;

--- a/Common_glTF_Exporter/Core/glTF.cs
+++ b/Common_glTF_Exporter/Core/glTF.cs
@@ -9,6 +9,7 @@ namespace Revit_glTF_Exporter
     /// </summary>
     public enum Targets
     {
+        NONE = 0,
         ARRAY_BUFFER = 34962, // signals vertex data
         ELEMENT_ARRAY_BUFFER = 34963, // signals index or face data
     }

--- a/Common_glTF_Exporter/Core/glTF.cs
+++ b/Common_glTF_Exporter/Core/glTF.cs
@@ -41,5 +41,7 @@ namespace Revit_glTF_Exporter
         public List<GLTFBufferView> bufferViews;
         public List<GLTFAccessor> accessors;
         public List<GLTFMaterial> materials;
+        public List<GLTFTexture> textures;
+        public List<GLTFImage> images;
     }
 }

--- a/Common_glTF_Exporter/Core/glTFPBR.cs
+++ b/Common_glTF_Exporter/Core/glTFPBR.cs
@@ -9,5 +9,9 @@
         public float metallicFactor { get; set; }
 
         public float roughnessFactor { get; set; }
+
+        // Texture properties
+        public GLTFTextureInfo baseColorTexture { get; set; }
+        public GLTFTexture metallicRoughnessTexture { get; set; }
     }
 }

--- a/Common_glTF_Exporter/Export/BinFile.cs
+++ b/Common_glTF_Exporter/Export/BinFile.cs
@@ -35,6 +35,14 @@
                         }
                     }
 
+                    if (bin.uvBuffer != null && bin.uvBuffer.Count > 0)
+                    {
+                        for (int i = 0; i < bin.uvBuffer.Count; i++)
+                        {
+                            writer.Write((float)bin.uvBuffer[i]);
+                        }
+                    }
+
                     if (exportBatchId)
                     {
                         for (int i = 0; i < bin.batchIdBuffer.Count; i++)

--- a/Common_glTF_Exporter/Export/BinFile.cs
+++ b/Common_glTF_Exporter/Export/BinFile.cs
@@ -1,5 +1,6 @@
 ﻿namespace Common_glTF_Exporter.Export
 {
+    using System;
     using System.Collections.Generic;
     using System.IO;
     using System.Text;
@@ -36,9 +37,13 @@
                         }
                     }
 
-
                     if (preferences.materials == MaterialsEnum.textures)
                     {
+                        if (bin.byteData != null)
+                        {
+                           writer.Write((byte[])bin.byteData);
+                        }
+
                         if (bin.uvBuffer != null && bin.uvBuffer.Count > 0)
                         {
                             for (int i = 0; i < bin.uvBuffer.Count; i++)
@@ -47,7 +52,6 @@
                             }
                         }
                     }
-
 
                     if (preferences.batchId)
                     {

--- a/Common_glTF_Exporter/Export/BinFile.cs
+++ b/Common_glTF_Exporter/Export/BinFile.cs
@@ -4,6 +4,7 @@
     using System.IO;
     using System.Text;
     using Common_glTF_Exporter.Core;
+    using Common_glTF_Exporter.Windows.MainWindow;
 
     public static class BinFile
     {
@@ -15,7 +16,7 @@
         /// <param name="exportNormals">export normals.</param>
         /// <param name="exportBatchId">export BatchId.</param>
         public static void Create(string filename, List<GLTFBinaryData> binaryFileData, 
-            bool exportNormals, bool exportBatchId)
+            Preferences preferences)
         {
             using (FileStream f = File.Create(filename))
             using (var writer = new BinaryWriter(new BufferedStream(f), Encoding.UTF8))
@@ -27,7 +28,7 @@
                         writer.Write((float)bin.vertexBuffer[i]);
                     }
 
-                    if (exportNormals)
+                    if (preferences.normals)
                     {
                         for (int i = 0; i < bin.normalBuffer.Count; i++)
                         {
@@ -35,15 +36,20 @@
                         }
                     }
 
-                    if (bin.uvBuffer != null && bin.uvBuffer.Count > 0)
+
+                    if (preferences.materials == MaterialsEnum.textures)
                     {
-                        for (int i = 0; i < bin.uvBuffer.Count; i++)
+                        if (bin.uvBuffer != null && bin.uvBuffer.Count > 0)
                         {
-                            writer.Write((float)bin.uvBuffer[i]);
+                            for (int i = 0; i < bin.uvBuffer.Count; i++)
+                            {
+                                writer.Write((float)bin.uvBuffer[i]);
+                            }
                         }
                     }
 
-                    if (exportBatchId)
+
+                    if (preferences.batchId)
                     {
                         for (int i = 0; i < bin.batchIdBuffer.Count; i++)
                         {

--- a/Common_glTF_Exporter/Export/FileExport.cs
+++ b/Common_glTF_Exporter/Export/FileExport.cs
@@ -32,7 +32,7 @@ namespace Common_glTF_Exporter.Export
             {
                 BufferConfig.Run(bufferViews, buffers, preferences);
                 string fileDirectory = string.Concat(preferences.path, BIN);
-                BinFile.Create(fileDirectory, binaryFileData, preferences.normals, preferences.batchId);
+                BinFile.Create(fileDirectory, binaryFileData, preferences);
 
                 string gltfJson = GltfJson.Get(scenes, nodes.List, meshes.List, materials.List, buffers,
                 bufferViews, accessors, textures, images, preferences);

--- a/Common_glTF_Exporter/Export/FileExport.cs
+++ b/Common_glTF_Exporter/Export/FileExport.cs
@@ -36,7 +36,8 @@ namespace Common_glTF_Exporter.Export
                 bufferViews, accessors, preferences);
 
                 string gltfName = string.Concat(preferences.path, GLTF);
-                File.WriteAllText(gltfName, gltfJson, Encoding.UTF8);
+                var utf8WithoutBom = new UTF8Encoding(encoderShouldEmitUTF8Identifier: false);
+                File.WriteAllText(gltfName, gltfJson, utf8WithoutBom);
             }
             else
             {

--- a/Common_glTF_Exporter/Export/FileExport.cs
+++ b/Common_glTF_Exporter/Export/FileExport.cs
@@ -24,7 +24,9 @@ namespace Common_glTF_Exporter.Export
             IndexedDictionary<GLTFNode> nodes,
             IndexedDictionary<GLTFMesh> meshes,
             IndexedDictionary<GLTFMaterial> materials,
-            List<GLTFAccessor> accessors)
+            List<GLTFAccessor> accessors,
+            List<GLTFTexture> textures,
+            List<GLTFImage> images)
         {
             if (preferences.format == FormatEnum.gltf)
             {
@@ -33,7 +35,7 @@ namespace Common_glTF_Exporter.Export
                 BinFile.Create(fileDirectory, binaryFileData, preferences.normals, preferences.batchId);
 
                 string gltfJson = GltfJson.Get(scenes, nodes.List, meshes.List, materials.List, buffers,
-                bufferViews, accessors, preferences);
+                bufferViews, accessors, textures, images, preferences);
 
                 string gltfName = string.Concat(preferences.path, GLTF);
                 var utf8WithoutBom = new UTF8Encoding(encoderShouldEmitUTF8Identifier: false);
@@ -44,11 +46,10 @@ namespace Common_glTF_Exporter.Export
                 BufferConfig.Run(bufferViews, buffers, preferences);
 
                 string gltfJson = GltfJson.Get(scenes, nodes.List, meshes.List, materials.List, buffers,
-                bufferViews, accessors, preferences);
+                bufferViews, accessors, textures, images, preferences);
 
                 GlbFile.Create(preferences, binaryFileData, gltfJson);
             }
-
         }
     }
 }

--- a/Common_glTF_Exporter/Export/GlbBinInfo.cs
+++ b/Common_glTF_Exporter/Export/GlbBinInfo.cs
@@ -4,12 +4,13 @@ using System.Linq;
 using System.Text;
 using Common_glTF_Exporter.Core;
 using Common_glTF_Exporter.Model;
+using Common_glTF_Exporter.Windows.MainWindow;
 
 namespace Common_glTF_Exporter.Export
 {
     public static class GlbBinInfo
     {
-        public static byte[] Get(List<GLTFBinaryData> binaryFileData, bool exportNormals, bool exportBatchId)
+        public static byte[] Get(List<GLTFBinaryData> binaryFileData, Preferences preferences)
         {
             List<byte> binData = new List<byte>();
 
@@ -21,7 +22,7 @@ namespace Common_glTF_Exporter.Export
                     binData.AddRange(vertex);
                 }
 
-                if (exportNormals)
+                if (preferences.normals)
                 {
                     foreach (var normal in bin.normalBuffer)
                     {
@@ -30,16 +31,19 @@ namespace Common_glTF_Exporter.Export
                     }
                 }
 
-                if (bin.uvBuffer != null && bin.uvBuffer.Count > 0)
+                if (preferences.materials == MaterialsEnum.textures)
                 {
-                    foreach (var uv in bin.uvBuffer)
+                    if (bin.uvBuffer != null && bin.uvBuffer.Count > 0)
                     {
-                        List<byte> uvBytes = BitConverter.GetBytes((float)uv).ToList();
-                        binData.AddRange(uvBytes);
+                        foreach (var uv in bin.uvBuffer)
+                        {
+                            List<byte> uvBytes = BitConverter.GetBytes((float)uv).ToList();
+                            binData.AddRange(uvBytes);
+                        }
                     }
                 }
 
-                if (exportBatchId)
+                if (preferences.batchId)
                 {
                     foreach (var batchId in bin.batchIdBuffer)
                     {

--- a/Common_glTF_Exporter/Export/GlbBinInfo.cs
+++ b/Common_glTF_Exporter/Export/GlbBinInfo.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
+using Autodesk.Revit.DB.Visual;
 using Common_glTF_Exporter.Core;
 using Common_glTF_Exporter.Model;
 using Common_glTF_Exporter.Windows.MainWindow;
@@ -33,6 +34,11 @@ namespace Common_glTF_Exporter.Export
 
                 if (preferences.materials == MaterialsEnum.textures)
                 {
+                    if (bin.byteData != null)
+                    {
+                        binData.AddRange(bin.byteData);
+                    }
+
                     if (bin.uvBuffer != null && bin.uvBuffer.Count > 0)
                     {
                         foreach (var uv in bin.uvBuffer)

--- a/Common_glTF_Exporter/Export/GlbBinInfo.cs
+++ b/Common_glTF_Exporter/Export/GlbBinInfo.cs
@@ -30,6 +30,15 @@ namespace Common_glTF_Exporter.Export
                     }
                 }
 
+                if (bin.uvBuffer != null && bin.uvBuffer.Count > 0)
+                {
+                    foreach (var uv in bin.uvBuffer)
+                    {
+                        List<byte> uvBytes = BitConverter.GetBytes((float)uv).ToList();
+                        binData.AddRange(uvBytes);
+                    }
+                }
+
                 if (exportBatchId)
                 {
                     foreach (var batchId in bin.batchIdBuffer)

--- a/Common_glTF_Exporter/Export/GlbFile.cs
+++ b/Common_glTF_Exporter/Export/GlbFile.cs
@@ -15,7 +15,7 @@ namespace Common_glTF_Exporter.Export
         {
             byte[] jsonChunk = GlbJsonInfo.Get(json);
             int lenggg = jsonChunk.Length;
-            byte[] binChunk = GlbBinInfo.Get(binaryFileData, preferences.normals, preferences.batchId);
+            byte[] binChunk = GlbBinInfo.Get(binaryFileData, preferences);
             byte[] headerChunk = GlbHeaderInfo.Get(jsonChunk, binChunk);
 
             string fileDirectory = string.Concat(preferences.path, ".glb");

--- a/Common_glTF_Exporter/Export/GlbFile.cs
+++ b/Common_glTF_Exporter/Export/GlbFile.cs
@@ -14,6 +14,7 @@ namespace Common_glTF_Exporter.Export
         public static void Create(Preferences preferences, List<GLTFBinaryData> binaryFileData, string json)
         {
             byte[] jsonChunk = GlbJsonInfo.Get(json);
+            int lenggg = jsonChunk.Length;
             byte[] binChunk = GlbBinInfo.Get(binaryFileData, preferences.normals, preferences.batchId);
             byte[] headerChunk = GlbHeaderInfo.Get(jsonChunk, binChunk);
 

--- a/Common_glTF_Exporter/Export/GlbJsonInfo.cs
+++ b/Common_glTF_Exporter/Export/GlbJsonInfo.cs
@@ -12,18 +12,31 @@ namespace Common_glTF_Exporter.Export
         {
             GlbJson glbJson = new GlbJson();
 
-            if (json.Length % 4 != 0)
+            // Convert JSON to UTF-8 byte array (DO THIS FIRST)
+            byte[] jsonBytes = Encoding.UTF8.GetBytes(json);
+
+            // Calculate padding needed to align to 4 bytes
+            int padding = (4 - (jsonBytes.Length % 4)) % 4;
+
+            // Allocate new array for padded JSON
+            byte[] paddedJsonBytes = new byte[jsonBytes.Length + padding];
+            Array.Copy(jsonBytes, paddedJsonBytes, jsonBytes.Length);
+
+            // Pad with spaces (0x20)
+            for (int i = jsonBytes.Length; i < paddedJsonBytes.Length; i++)
             {
-                int missingNumbers = 4 - (json.Length % 4);
-                json = json.PadRight(json.Length + missingNumbers);
+                paddedJsonBytes[i] = 0x20;
             }
 
-            glbJson.ChunkData = Encoding.UTF8.GetBytes(json);
+            glbJson.ChunkData = paddedJsonBytes;
+
+            // Write chunk length (uint32)
             glbJson.Length = BitConverter.GetBytes(Convert.ToUInt32(glbJson.ChunkData.Length));
 
+            // Build JSON chunk: length + type + data
             byte[] result = new byte[] { };
             result = result.Concat(glbJson.Length).ToArray();
-            result = result.Concat(glbJson.ChunkType()).ToArray();
+            result = result.Concat(glbJson.ChunkType()).ToArray(); // Should return 4-byte ASCII for "JSON"
             result = result.Concat(glbJson.ChunkData).ToArray();
 
             return result;

--- a/Common_glTF_Exporter/Export/GltfJson.cs
+++ b/Common_glTF_Exporter/Export/GltfJson.cs
@@ -38,14 +38,17 @@ namespace Common_glTF_Exporter.Export
                 model.materials = materials;
             }
 
-            if (textures.Any())
+            if (preferences.materials == MaterialsEnum.textures)
             {
-                model.textures = textures;
-            }
+                if (textures.Any())
+                {
+                    model.textures = textures;
+                }
 
-            if (images.Any())
-            {
-                model.images = images;
+                if (images.Any())
+                {
+                    model.images = images;
+                }
             }
 
             model.buffers = buffers;
@@ -66,6 +69,11 @@ namespace Common_glTF_Exporter.Export
             if (!preferences.normals)
             {
                 serializedModel = serializedModel.Replace(",\"NORMAL\":0", string.Empty);
+            }
+
+            if (preferences.materials != MaterialsEnum.textures)
+            {
+                serializedModel = serializedModel.Replace(",\"TEXCOORD_0\":0", string.Empty);
             }
 
             return serializedModel;

--- a/Common_glTF_Exporter/Export/GltfJson.cs
+++ b/Common_glTF_Exporter/Export/GltfJson.cs
@@ -60,22 +60,6 @@ namespace Common_glTF_Exporter.Export
                 model,
                 new JsonSerializerSettings { NullValueHandling = NullValueHandling.Ignore });
 
-
-            if (!preferences.batchId)
-            {
-                serializedModel = serializedModel.Replace(",\"_BATCHID\":0", string.Empty);
-            }
-
-            if (!preferences.normals)
-            {
-                serializedModel = serializedModel.Replace(",\"NORMAL\":0", string.Empty);
-            }
-
-            if (preferences.materials != MaterialsEnum.textures)
-            {
-                serializedModel = serializedModel.Replace(",\"TEXCOORD_0\":0", string.Empty);
-            }
-
             return serializedModel;
         }
     }

--- a/Common_glTF_Exporter/Export/GltfJson.cs
+++ b/Common_glTF_Exporter/Export/GltfJson.cs
@@ -24,7 +24,7 @@ namespace Common_glTF_Exporter.Export
             List<GLTFImage> images,
             Preferences preferences)
         {
-            // Package the properties into a serializable container
+
             GLTF model = new GLTF
             {
                 asset = new GLTFVersion(),
@@ -32,6 +32,11 @@ namespace Common_glTF_Exporter.Export
                 nodes = nodes,
                 meshes = meshes,
             };
+
+            if (preferences.materials == MaterialsEnum.textures)
+            {
+                model.extensionsUsed = new List<string> { "KHR_texture_transform" };
+            }
 
             if (materials.Any())
             {

--- a/Common_glTF_Exporter/Export/GltfJson.cs
+++ b/Common_glTF_Exporter/Export/GltfJson.cs
@@ -20,6 +20,8 @@ namespace Common_glTF_Exporter.Export
             List<GLTFBuffer> buffers,
             List<GLTFBufferView> bufferViews,
             List<GLTFAccessor> accessors,
+            List<GLTFTexture> textures,
+            List<GLTFImage> images,
             Preferences preferences)
         {
             // Package the properties into a serializable container
@@ -34,6 +36,16 @@ namespace Common_glTF_Exporter.Export
             if (materials.Any())
             {
                 model.materials = materials;
+            }
+
+            if (textures.Any())
+            {
+                model.textures = textures;
+            }
+
+            if (images.Any())
+            {
+                model.images = images;
             }
 
             model.buffers = buffers;

--- a/Common_glTF_Exporter/Export/RevitMaterials.cs
+++ b/Common_glTF_Exporter/Export/RevitMaterials.cs
@@ -14,8 +14,6 @@
         const string BLEND = "BLEND";
         const string OPAQUE = "OPAQUE";
         const int ONEINTVALUE = 1;
-        const string GENERIC_DIFFUSE = "GenericDiffuse";
-        const string UNIFIED_BITMAP = "UnifiedBitmap";
 
         /// <summary>
         /// Container for material names (Local cache to avoid Revit API I/O)
@@ -25,35 +23,27 @@
         /// <summary>
         /// Export Revit materials.
         /// </summary>
-        /// <param name="node">node.</param>
-        /// <param name="doc">Revit document.</param>
-        /// <param name="materials">Materials.</param>
-        /// <param name="textures">Textures list.</param>
-        /// <param name="images">Images list.</param>
-        public static void Export(MaterialNode node, 
-            Document doc, 
-            ref IndexedDictionary<GLTFMaterial> materials, 
-            List<GLTFTexture> textures, 
-            List<GLTFImage> images,
+        public static GLTFMaterial Export(MaterialNode node,
+            Document doc,
+            ref IndexedDictionary<GLTFMaterial> materials,
             Preferences preferences)
         {
             ElementId id = node.MaterialId;
             GLTFMaterial gl_mat = new GLTFMaterial();
             float opacity = ONEINTVALUE - (float)node.Transparency;
 
-            // Validate if the material is valid because for some reason there are
-            // materials with invalid Ids
+
             if (id != ElementId.InvalidElementId)
             {
                 string uniqueId;
                 Material material = null;
+
                 if (!MaterialNameContainer.TryGetValue(node.MaterialId, out var materialElement))
                 {
-                    // construct a material from the node
-                    material = doc.GetElement(node.MaterialId) as Material;
-                    gl_mat.name = material.Name;
-                    uniqueId = material.UniqueId;
-                    MaterialNameContainer.Add(node.MaterialId, new MaterialCacheDTO(material.Name, material.UniqueId));
+                     material = doc.GetElement(node.MaterialId) as Material;
+                     gl_mat.name = material.Name;
+                     uniqueId = material.UniqueId;
+                     MaterialNameContainer.Add(node.MaterialId, new MaterialCacheDTO(material.Name, material.UniqueId));
                 }
                 else
                 {
@@ -63,161 +53,94 @@
                     material = doc.GetElement(node.MaterialId) as Material;
                 }
 
+                // Set PBR values
                 GLTFPBR pbr = new GLTFPBR();
                 SetMaterialsProperties(node, opacity, ref pbr, ref gl_mat);
 
-
+                // Instead of embedding the image now, just store the path for future export
                 if (material != null && preferences.materials == MaterialsEnum.textures)
                 {
-                    ExtractAndSetTexture(material, doc, ref gl_mat, textures, images);
+                    string texturePath = TryGetTexturePath(material, doc);
+                    if (!string.IsNullOrEmpty(texturePath) && File.Exists(texturePath))
+                    {
+                        gl_mat.EmbeddedTexturePath = texturePath;
+                    }
+
+                    gl_mat.pbrMetallicRoughness.baseColorTexture = new GLTFTextureInfo
+                    {
+                        index = 0 // This will be correctly updated in `AddGeometryMeta`
+                    };
                 }
 
                 materials.AddOrUpdateCurrentMaterial(uniqueId, gl_mat, false);
             }
+
+            return gl_mat;
         }
 
         private static void SetMaterialsProperties(MaterialNode node, float opacity, ref GLTFPBR pbr, ref GLTFMaterial gl_mat)
         {
-            pbr.baseColorFactor = new List<float>(4) { node.Color.Red / 255f, node.Color.Green / 255f, node.Color.Blue / 255f, opacity };
+            pbr.baseColorFactor = new List<float>(4)
+            {
+                node.Color.Red / 255f,
+                node.Color.Green / 255f,
+                node.Color.Blue / 255f,
+                opacity
+            };
+
             pbr.metallicFactor = 0f;
             pbr.roughnessFactor = opacity != 1 ? 0.5f : 1f;
             gl_mat.pbrMetallicRoughness = pbr;
 
-            // TODO: Implement MASK alphamode for elements like leaves or wire fences
             gl_mat.alphaMode = opacity != 1 ? BLEND : OPAQUE;
             gl_mat.alphaCutoff = null;
         }
 
-        private static void ExtractAndSetTexture(Material material, Document doc, ref GLTFMaterial gl_mat, List<GLTFTexture> textures, List<GLTFImage> images)
+        /// <summary>
+        /// Extracts the texture path from the material’s AppearanceAsset, if present.
+        /// </summary>
+        private static string TryGetTexturePath(Material material, Document doc)
         {
             try
             {
                 ElementId appearanceId = material.AppearanceAssetId;
                 if (appearanceId == ElementId.InvalidElementId)
-                    return;
+                    return null;
 
-                AppearanceAssetElement appearanceElem = doc.GetElement(appearanceId) as AppearanceAssetElement;
+                var appearanceElem = doc.GetElement(appearanceId) as AppearanceAssetElement;
                 if (appearanceElem == null)
-                    return;
+                    return null;
 
                 Asset theAsset = appearanceElem.GetRenderingAsset();
-                AssetProperty ap = theAsset.FindByName(GENERIC_DIFFUSE);
+                AssetProperty prop = theAsset.FindByName("opaque_albedo");
 
-                string texturePath = null;
-
-                if (ap != null && ap.NumberOfConnectedProperties > 0)
+                if (prop != null && prop.NumberOfConnectedProperties > 0)
                 {
-                    var connectedAsset = ap.GetSingleConnectedAsset();
-                    AssetPropertyString bitmapPathProp = connectedAsset.FindByName(UNIFIED_BITMAP) as AssetPropertyString;
+                    var connectedAsset = prop.GetSingleConnectedAsset();
+                    var bitmapPathProp = connectedAsset.FindByName("unifiedbitmap_Bitmap") as AssetPropertyString;
 
                     if (bitmapPathProp != null)
                     {
-                        texturePath = bitmapPathProp.Value.Split('|')[0];
+                        string texturePath = bitmapPathProp.Value.Split('|')[0].Replace("/", "\\");
+
                         if (!Path.IsPathRooted(texturePath))
                         {
-                            texturePath = Path.Combine(Path.GetDirectoryName(doc.PathName), texturePath);
+                            string materialsPath = Path.Combine(
+                                Environment.GetFolderPath(Environment.SpecialFolder.CommonProgramFiles),
+                                @"Autodesk Shared\Materials\Textures\");
+                            texturePath = Path.Combine(materialsPath, texturePath);
                         }
+
+                        return texturePath;
                     }
-                }
-                else
-                {
-                    int size = theAsset.Size;
-                    if (size == 0) return;
-
-                    for (int assetIdx = 0; assetIdx < size; assetIdx++)
-                    {
-                        var prop = theAsset.Get(assetIdx);
-                        if (prop.NumberOfConnectedProperties > 0)
-                        {
-                            var connectedAsset = prop.GetSingleConnectedAsset();
-                            AssetPropertyString bitmapPathProp = connectedAsset.FindByName("unifiedbitmap_Bitmap") as AssetPropertyString;
-
-                            if (bitmapPathProp != null &&  prop.Name.ToLower().Contains("opaque_albedo"))
-                            {
-                                texturePath = bitmapPathProp.Value.Split('|')[0];
-                                texturePath = texturePath.Replace("/", "\\");
-                                string MaterialsPath = System.IO.Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.CommonProgramFiles), @"Autodesk Shared\Materials\Textures\");
-                                if (!Path.IsPathRooted(texturePath))
-                                {
-                                    texturePath = Path.Combine(MaterialsPath, texturePath);
-                                    string destinationRoot = @"C:\Users\User\Desktop";
-                                    string texturesFolder = Path.Combine(destinationRoot, "textures");
-                                    Directory.CreateDirectory(texturesFolder);
-
-                                    string fileName = Path.GetFileName(texturePath);
-                                    string destinationFilePath = Path.Combine(texturesFolder, fileName);
-
-                                    File.Copy(texturePath, destinationFilePath);
-
-                                    Uri rootUri = new Uri(destinationRoot + Path.DirectorySeparatorChar);
-                                    Uri fileUri = new Uri(destinationFilePath);
-                                    texturePath = Uri.UnescapeDataString(rootUri.MakeRelativeUri(fileUri).ToString());
-                                }
-                                break;
-                            }
-                        }
-                    }
-                }
-
-                if (!string.IsNullOrEmpty(texturePath))
-                {
-                    AddTextureToMaterial(texturePath, ref gl_mat, textures, images);
                 }
             }
             catch (Exception ex)
             {
-                System.Diagnostics.Debug.WriteLine($"Error extracting texture from material {material.Name}: {ex.Message}");
+                System.Diagnostics.Debug.WriteLine($"Error extracting texture path from material {material.Name}: {ex.Message}");
             }
-        }
 
-        private static void AddTextureToMaterial(string path, ref GLTFMaterial gl_mat, List<GLTFTexture> textures, List<GLTFImage> images)
-        {
-            // 1. Add image
-            var image = new GLTFImage
-            {
-                uri = path,
-                mimeType = GetMimeType(path)
-            };
-            images.Add(image);
-            int imageIndex = images.Count - 1;
-
-            // 2. Add texture referencing the image
-            var texture = new GLTFTexture
-            {
-                source = imageIndex
-            };
-            textures.Add(texture);
-            int textureIndex = textures.Count - 1;
-
-            // 3. Add texture info to the material
-            var textureInfo = new GLTFTextureInfo
-            {
-                index = textureIndex,
-                texCoord = 0
-            };
-
-            gl_mat.pbrMetallicRoughness.baseColorTexture = textureInfo;
-        }
-
-        private static string GetMimeType(string path)
-        {
-            string extension = Path.GetExtension(path).ToLower();
-            switch (extension)
-            {
-                case ".jpg":
-                case ".jpeg":
-                    return "image/jpeg";
-                case ".png":
-                    return "image/png";
-                case ".bmp":
-                    return "image/bmp";
-                case ".gif":
-                    return "image/gif";
-                case ".webp":
-                    return "image/webp";
-                default:
-                    return "image/png"; // Default to PNG if unknown
-            }
+            return null;
         }
     }
 
@@ -230,7 +153,6 @@
         }
 
         public string MaterialName { get; set; }
-
         public string UniqueId { get; set; }
     }
 }

--- a/Common_glTF_Exporter/Export/RevitMaterials.cs
+++ b/Common_glTF_Exporter/Export/RevitMaterials.cs
@@ -6,6 +6,7 @@
     using Autodesk.Revit.DB;
     using Autodesk.Revit.DB.Visual;
     using Common_glTF_Exporter.Core;
+    using Common_glTF_Exporter.Windows.MainWindow;
     using Revit_glTF_Exporter;
 
     public static class RevitMaterials
@@ -29,7 +30,12 @@
         /// <param name="materials">Materials.</param>
         /// <param name="textures">Textures list.</param>
         /// <param name="images">Images list.</param>
-        public static void Export(MaterialNode node, Document doc, ref IndexedDictionary<GLTFMaterial> materials, List<GLTFTexture> textures, List<GLTFImage> images)
+        public static void Export(MaterialNode node, 
+            Document doc, 
+            ref IndexedDictionary<GLTFMaterial> materials, 
+            List<GLTFTexture> textures, 
+            List<GLTFImage> images,
+            Preferences preferences)
         {
             ElementId id = node.MaterialId;
             GLTFMaterial gl_mat = new GLTFMaterial();
@@ -60,8 +66,8 @@
                 GLTFPBR pbr = new GLTFPBR();
                 SetMaterialsProperties(node, opacity, ref pbr, ref gl_mat);
 
-                // Extract and set texture if available
-                if (material != null)
+
+                if (material != null && preferences.materials == MaterialsEnum.textures)
                 {
                     ExtractAndSetTexture(material, doc, ref gl_mat, textures, images);
                 }

--- a/Common_glTF_Exporter/Export/RevitMaterials.cs
+++ b/Common_glTF_Exporter/Export/RevitMaterials.cs
@@ -25,7 +25,6 @@
         /// Export Revit materials.
         /// </summary>
         public static GLTFMaterial Export(MaterialNode node,
-            Document doc,
             ref IndexedDictionary<GLTFMaterial> materials,
             Preferences preferences)
         {
@@ -33,6 +32,7 @@
             GLTFMaterial gl_mat = new GLTFMaterial();
             float opacity = ONEINTVALUE - (float)node.Transparency;
 
+            Document doc = ExternalApplication.RevitCollectorService.GetDocument();
 
             if (id != ElementId.InvalidElementId)
             {
@@ -75,7 +75,7 @@
 
                         gl_mat.pbrMetallicRoughness.baseColorTexture = new GLTFTextureInfo
                         {
-                            index = 0, // This will be correctly updated in `AddGeometryMeta`
+                            index = -1, // This will be correctly updated in `AddGeometryMeta`
                             extensions = new GLTFTextureExtensions
                             {
                                 TextureTransform = new GLTFTextureTransform

--- a/Common_glTF_Exporter/Export/RevitMaterials.cs
+++ b/Common_glTF_Exporter/Export/RevitMaterials.cs
@@ -1,7 +1,10 @@
 ﻿namespace Common_glTF_Exporter.Export
 {
+    using System;
     using System.Collections.Generic;
+    using System.IO;
     using Autodesk.Revit.DB;
+    using Autodesk.Revit.DB.Visual;
     using Common_glTF_Exporter.Core;
     using Revit_glTF_Exporter;
 
@@ -10,6 +13,8 @@
         const string BLEND = "BLEND";
         const string OPAQUE = "OPAQUE";
         const int ONEINTVALUE = 1;
+        const string GENERIC_DIFFUSE = "GenericDiffuse";
+        const string UNIFIED_BITMAP = "UnifiedBitmap";
 
         /// <summary>
         /// Container for material names (Local cache to avoid Revit API I/O)
@@ -22,7 +27,9 @@
         /// <param name="node">node.</param>
         /// <param name="doc">Revit document.</param>
         /// <param name="materials">Materials.</param>
-        public static void Export(MaterialNode node, Document doc, ref IndexedDictionary<GLTFMaterial> materials)
+        /// <param name="textures">Textures list.</param>
+        /// <param name="images">Images list.</param>
+        public static void Export(MaterialNode node, Document doc, ref IndexedDictionary<GLTFMaterial> materials, List<GLTFTexture> textures, List<GLTFImage> images)
         {
             ElementId id = node.MaterialId;
             GLTFMaterial gl_mat = new GLTFMaterial();
@@ -33,23 +40,31 @@
             if (id != ElementId.InvalidElementId)
             {
                 string uniqueId;
+                Material material = null;
                 if (!MaterialNameContainer.TryGetValue(node.MaterialId, out var materialElement))
                 {
                     // construct a material from the node
-                    var m = doc.GetElement(node.MaterialId);
-                    gl_mat.name = m.Name;
-                    uniqueId = m.UniqueId;
-                    MaterialNameContainer.Add(node.MaterialId, new MaterialCacheDTO(m.Name, m.UniqueId));
+                    material = doc.GetElement(node.MaterialId) as Material;
+                    gl_mat.name = material.Name;
+                    uniqueId = material.UniqueId;
+                    MaterialNameContainer.Add(node.MaterialId, new MaterialCacheDTO(material.Name, material.UniqueId));
                 }
                 else
                 {
                     var elementData = MaterialNameContainer[node.MaterialId];
                     gl_mat.name = elementData.MaterialName;
                     uniqueId = elementData.UniqueId;
+                    material = doc.GetElement(node.MaterialId) as Material;
                 }
 
                 GLTFPBR pbr = new GLTFPBR();
                 SetMaterialsProperties(node, opacity, ref pbr, ref gl_mat);
+
+                // Extract and set texture if available
+                if (material != null)
+                {
+                    ExtractAndSetTexture(material, doc, ref gl_mat, textures, images);
+                }
 
                 materials.AddOrUpdateCurrentMaterial(uniqueId, gl_mat, false);
             }
@@ -65,6 +80,138 @@
             // TODO: Implement MASK alphamode for elements like leaves or wire fences
             gl_mat.alphaMode = opacity != 1 ? BLEND : OPAQUE;
             gl_mat.alphaCutoff = null;
+        }
+
+        private static void ExtractAndSetTexture(Material material, Document doc, ref GLTFMaterial gl_mat, List<GLTFTexture> textures, List<GLTFImage> images)
+        {
+            try
+            {
+                ElementId appearanceId = material.AppearanceAssetId;
+                if (appearanceId == ElementId.InvalidElementId)
+                    return;
+
+                AppearanceAssetElement appearanceElem = doc.GetElement(appearanceId) as AppearanceAssetElement;
+                if (appearanceElem == null)
+                    return;
+
+                Asset theAsset = appearanceElem.GetRenderingAsset();
+                AssetProperty ap = theAsset.FindByName(GENERIC_DIFFUSE);
+
+                string texturePath = null;
+
+                if (ap != null && ap.NumberOfConnectedProperties > 0)
+                {
+                    var connectedAsset = ap.GetSingleConnectedAsset();
+                    AssetPropertyString bitmapPathProp = connectedAsset.FindByName(UNIFIED_BITMAP) as AssetPropertyString;
+
+                    if (bitmapPathProp != null)
+                    {
+                        texturePath = bitmapPathProp.Value.Split('|')[0];
+                        if (!Path.IsPathRooted(texturePath))
+                        {
+                            texturePath = Path.Combine(Path.GetDirectoryName(doc.PathName), texturePath);
+                        }
+                    }
+                }
+                else
+                {
+                    int size = theAsset.Size;
+                    if (size == 0) return;
+
+                    for (int assetIdx = 0; assetIdx < size; assetIdx++)
+                    {
+                        var prop = theAsset.Get(assetIdx);
+                        if (prop.NumberOfConnectedProperties > 0)
+                        {
+                            var connectedAsset = prop.GetSingleConnectedAsset();
+                            AssetPropertyString bitmapPathProp = connectedAsset.FindByName("unifiedbitmap_Bitmap") as AssetPropertyString;
+
+                            if (bitmapPathProp != null &&  prop.Name.ToLower().Contains("opaque_albedo"))
+                            {
+                                texturePath = bitmapPathProp.Value.Split('|')[0];
+                                texturePath = texturePath.Replace("/", "\\");
+                                string MaterialsPath = System.IO.Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.CommonProgramFiles), @"Autodesk Shared\Materials\Textures\");
+                                if (!Path.IsPathRooted(texturePath))
+                                {
+                                    texturePath = Path.Combine(MaterialsPath, texturePath);
+                                    string destinationRoot = @"C:\Users\User\Desktop";
+                                    string texturesFolder = Path.Combine(destinationRoot, "textures");
+                                    Directory.CreateDirectory(texturesFolder);
+
+                                    string fileName = Path.GetFileName(texturePath);
+                                    string destinationFilePath = Path.Combine(texturesFolder, fileName);
+
+                                    File.Copy(texturePath, destinationFilePath);
+
+                                    Uri rootUri = new Uri(destinationRoot + Path.DirectorySeparatorChar);
+                                    Uri fileUri = new Uri(destinationFilePath);
+                                    texturePath = Uri.UnescapeDataString(rootUri.MakeRelativeUri(fileUri).ToString());
+                                }
+                                break;
+                            }
+                        }
+                    }
+                }
+
+                if (!string.IsNullOrEmpty(texturePath))
+                {
+                    AddTextureToMaterial(texturePath, ref gl_mat, textures, images);
+                }
+            }
+            catch (Exception ex)
+            {
+                System.Diagnostics.Debug.WriteLine($"Error extracting texture from material {material.Name}: {ex.Message}");
+            }
+        }
+
+        private static void AddTextureToMaterial(string path, ref GLTFMaterial gl_mat, List<GLTFTexture> textures, List<GLTFImage> images)
+        {
+            // 1. Add image
+            var image = new GLTFImage
+            {
+                uri = path,
+                mimeType = GetMimeType(path)
+            };
+            images.Add(image);
+            int imageIndex = images.Count - 1;
+
+            // 2. Add texture referencing the image
+            var texture = new GLTFTexture
+            {
+                source = imageIndex
+            };
+            textures.Add(texture);
+            int textureIndex = textures.Count - 1;
+
+            // 3. Add texture info to the material
+            var textureInfo = new GLTFTextureInfo
+            {
+                index = textureIndex,
+                texCoord = 0
+            };
+
+            gl_mat.pbrMetallicRoughness.baseColorTexture = textureInfo;
+        }
+
+        private static string GetMimeType(string path)
+        {
+            string extension = Path.GetExtension(path).ToLower();
+            switch (extension)
+            {
+                case ".jpg":
+                case ".jpeg":
+                    return "image/jpeg";
+                case ".png":
+                    return "image/png";
+                case ".bmp":
+                    return "image/bmp";
+                case ".gif":
+                    return "image/gif";
+                case ".webp":
+                    return "image/webp";
+                default:
+                    return "image/png"; // Default to PNG if unknown
+            }
         }
     }
 

--- a/Common_glTF_Exporter/ExternalApplication.cs
+++ b/Common_glTF_Exporter/ExternalApplication.cs
@@ -10,12 +10,14 @@
     using System.Linq;
     using System.Windows.Media;
     using System.Windows;
+    using Common_glTF_Exporter.Service;
 
     /// <summary>
     /// External Application.
     /// </summary>
     public class ExternalApplication : IExternalApplication
     {
+        public static RevitCollectorService RevitCollectorService;
         private static readonly string RIBBONTAB = "e-verse";
         private static readonly string RIBBONPANEL = "Export glTF";
         private static readonly string LEIAURL = @"https://e-verse.com/leia-gltf-exporter/";
@@ -23,6 +25,7 @@
         private static string pushButtonText = "Leia";
         private static string addInPath = typeof(ExternalApplication).Assembly.Location;
         private static string buttonIconsFolder = Path.GetDirectoryName(addInPath) + "\\Images\\";
+
         internal Document Document { get; set; }
         public static UIApplication UiApp { get; private set; }
 
@@ -64,6 +67,8 @@
         /// <returns>Result.</returns>
         public Result OnStartup(UIControlledApplication application)
         {
+            RevitCollectorService = new RevitCollectorService(application.GetUIApplication());
+
             // -- Events Subscription
             application.ViewActivated += Application_ViewActivated;
 

--- a/Common_glTF_Exporter/ExternalApplication.cs
+++ b/Common_glTF_Exporter/ExternalApplication.cs
@@ -145,7 +145,7 @@
             #pragma warning restore CS4014
         }
 
-        private BitmapSource CreateLogo(string logoPath, double size = 32)
+        private BitmapSource CreateLogo(string logoPath, double size = 25)
         {
             Geometry pathGeometry = PathGeometry.Parse(logoPath);
             Rect bounds = pathGeometry.Bounds;

--- a/Common_glTF_Exporter/ExternalCommand.cs
+++ b/Common_glTF_Exporter/ExternalCommand.cs
@@ -31,7 +31,7 @@
                     return Result.Succeeded;
                 }
 
-                MainWindow mainWindow = new MainWindow(doc, view);
+                MainWindow mainWindow = new MainWindow(view);
                 mainWindow.ShowDialog();
 
                 return Result.Succeeded;

--- a/Common_glTF_Exporter/Model/GeometryDataObject.cs
+++ b/Common_glTF_Exporter/Model/GeometryDataObject.cs
@@ -1,5 +1,6 @@
 ﻿namespace Common_glTF_Exporter.Model
 {
+    using Autodesk.Revit.DB;
     using System.Collections.Generic;
 
     /// <summary>
@@ -11,8 +12,9 @@
 
         public List<double> Normals { get; set; } = new List<double>();
 
-        public List<double> Uvs { get; set; } = new List<double>();
+        public List<UV> Uvs { get; set; } = new List<UV>();
 
         public List<int> Faces { get; set; } = new List<int>();
+
     }
 }

--- a/Common_glTF_Exporter/Service/RevitCollectorService.cs
+++ b/Common_glTF_Exporter/Service/RevitCollectorService.cs
@@ -1,0 +1,27 @@
+﻿using Autodesk.Revit.DB;
+using Autodesk.Revit.UI;
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Common_glTF_Exporter.Service
+{
+    public class RevitCollectorService
+    {
+        private UIApplication uiApplication;
+
+        public RevitCollectorService(UIApplication uIApplication)
+        {
+            uiApplication = uIApplication;
+        }
+
+        /// <summary>
+        /// Get current active document
+        /// </summary>
+        /// <returns></returns>
+        public Document GetDocument()
+        {
+            return uiApplication.ActiveUIDocument.Document;
+        }
+    }
+}

--- a/Common_glTF_Exporter/Service/UIApplicationExtension.cs
+++ b/Common_glTF_Exporter/Service/UIApplicationExtension.cs
@@ -1,0 +1,27 @@
+﻿using Autodesk.Revit.UI;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using System.Text;
+
+namespace Common_glTF_Exporter.Service
+{
+    internal static class UIApplicationExtension
+    {
+        //https://forums.autodesk.com/t5/revit-api-forum/how-to-get-uiapplication-from-iexternalapplication/td-p/6355729
+        /// <summary>
+        /// Get <see cref="Autodesk.Revit.UI.UIApplication"/> using the <paramref name="application"/>
+        /// </summary>
+        /// <param name="application">Revit UIApplication</param>
+        public static UIApplication GetUIApplication(this UIControlledApplication application)
+        {
+            var type = typeof(UIControlledApplication);
+
+            var propertie = type.GetFields(BindingFlags.Instance | BindingFlags.NonPublic)
+                .FirstOrDefault(e => e.FieldType == typeof(UIApplication));
+
+            return propertie?.GetValue(application) as UIApplication;
+        }
+    }
+}

--- a/Common_glTF_Exporter/Utils/GLTFBinaryDataUtils.cs
+++ b/Common_glTF_Exporter/Utils/GLTFBinaryDataUtils.cs
@@ -152,11 +152,6 @@
 
             int uvCount = geomData.Uvs.Count;
 
-            if (uvCount == 0)
-            {
-                string tet = "Dsdsdsd";
-            }
-
             // Convert UVs to float buffer (U, V per entry)
             foreach (var uv in geomData.Uvs)
             {

--- a/Common_glTF_Exporter/Utils/GLTFBinaryDataUtils.cs
+++ b/Common_glTF_Exporter/Utils/GLTFBinaryDataUtils.cs
@@ -150,6 +150,13 @@
             const string VEC2_STR = "VEC2";
             const string TEXCOORD_STR = "TEXCOORD_0";
 
+            int uvCount = geomData.Uvs.Count;
+
+            if (uvCount == 0)
+            {
+                string tet = "Dsdsdsd";
+            }
+
             // Convert UVs to float buffer (U, V per entry)
             foreach (var uv in geomData.Uvs)
             {
@@ -160,7 +167,8 @@
             int elementsPerUV = 2;
             int bytesPerUVElement = 4;
             int bytesPerUV = elementsPerUV * bytesPerUVElement;
-            int uvCount = geomData.Uvs.Count;
+
+
             int sizeOfUVView = uvCount * bytesPerUV;
 
             // Create UV buffer view

--- a/Common_glTF_Exporter/Utils/MaterialUtils.cs
+++ b/Common_glTF_Exporter/Utils/MaterialUtils.cs
@@ -27,7 +27,7 @@
 
             Material material = MaterialUtils.GetMeshMaterial(doc, mesh);
 
-            if (preferences.materials)
+            if (preferences.materials == MaterialsEnum.materials)
             {
                 if (material == null)
                 {

--- a/Common_glTF_Exporter/Utils/MaterialUtils.cs
+++ b/Common_glTF_Exporter/Utils/MaterialUtils.cs
@@ -27,7 +27,7 @@
 
             Material material = MaterialUtils.GetMeshMaterial(doc, mesh);
 
-            if (preferences.materials == MaterialsEnum.materials)
+            if (preferences.materials == MaterialsEnum.materials || preferences.materials == MaterialsEnum.textures)
             {
                 if (material == null)
                 {

--- a/Common_glTF_Exporter/Utils/Theme.cs
+++ b/Common_glTF_Exporter/Utils/Theme.cs
@@ -31,7 +31,8 @@ namespace Common_glTF_Exporter.Utils
                 { "SecondaryGray",  "#ffffff"},
                 { "HoverGray", "#465162" },
                 { "WhiteColour", "#18263c"},
-                { "AuxiliaryGray", "#667075"}
+                { "AuxiliaryGray", "#667075"},
+                { "SecondaryBackgroundColor", "#515a6c"}
         };
 
             foreach (var entry in colorMappings)

--- a/Common_glTF_Exporter/Utils/Util.cs
+++ b/Common_glTF_Exporter/Utils/Util.cs
@@ -303,6 +303,25 @@ namespace Revit_glTF_Exporter
             return parametersDictionary;
         }
 
+        public static float[] GetVec2MinMax(List<float> vec2List)
+        {
+            float minU = float.MaxValue, minV = float.MaxValue;
+            float maxU = float.MinValue, maxV = float.MinValue;
+
+            for (int i = 0; i < vec2List.Count; i += 2)
+            {
+                float u = vec2List[i];
+                float v = vec2List[i + 1];
+
+                if (u < minU) minU = u;
+                if (u > maxU) maxU = u;
+                if (v < minV) minV = v;
+                if (v > maxV) maxV = v;
+            }
+
+            return new float[] { minU, maxU, minV, maxV };
+        }
+
         private static string GetParameterValue(Parameter parameter)
         {
             if (parameter.StorageType == StorageType.String)

--- a/Common_glTF_Exporter/Utils/glTFExportUtils.cs
+++ b/Common_glTF_Exporter/Utils/glTFExportUtils.cs
@@ -135,18 +135,16 @@
                     {
                         List<XYZ> normalPoints = new List<XYZ>
                         {
-                            transform.OfVector(polymeshNormals[facet.V1]),
-                            transform.OfVector(polymeshNormals[facet.V2]),
-                            transform.OfVector(polymeshNormals[facet.V3]),
+                            transform.OfVector(polymeshNormals[facet.V1]).Normalize(),
+                            transform.OfVector(polymeshNormals[facet.V2]).Normalize(),
+                            transform.OfVector(polymeshNormals[facet.V3]).Normalize(),
                         };
 
                         foreach (var normalPoint in normalPoints)
                         {
-                            XYZ newNormalPoint = normalPoint;
-
-                            normals.Add(newNormalPoint.X);
-                            normals.Add(newNormalPoint.Y);
-                            normals.Add(newNormalPoint.Z);
+                            normals.Add(normalPoint.X);
+                            normals.Add(normalPoint.Y);
+                            normals.Add(normalPoint.Z);
                         }
                     }
 
@@ -159,7 +157,7 @@
                     {
                         foreach (var normal in polymesh.GetNormals())
                         {
-                            var newNormal = normal;
+                            var newNormal = transform.OfVector(normal).Normalize();
 
                             for (int j = 0; j < 3; j++)
                             {
@@ -177,7 +175,7 @@
                 {
                     foreach (XYZ normal in polymeshNormals)
                     {
-                        var newNormal = transform.OfVector(normal);
+                        var newNormal = transform.OfVector(normal).Normalize();
 
                         normals.Add(newNormal.X);
                         normals.Add(newNormal.Y);

--- a/Common_glTF_Exporter/Utils/glTFExportUtils.cs
+++ b/Common_glTF_Exporter/Utils/glTFExportUtils.cs
@@ -94,7 +94,13 @@
         /// <param name="exportBatchId">exportBatchId.</param>
         /// <param name="exportNormals">exportNormals.</param>
         /// <returns>Returns the GLTFBinaryData object.</returns>
-        public static GLTFBinaryData AddGeometryMeta(List<GLTFBuffer> buffers, List<GLTFAccessor> accessors, List<GLTFBufferView> bufferViews, GeometryDataObject geomData, string name, long elementId, bool exportBatchId, bool exportNormals)
+        public static GLTFBinaryData AddGeometryMeta(List<GLTFBuffer> buffers, 
+            List<GLTFAccessor> accessors, 
+            List<GLTFBufferView> bufferViews, 
+            GeometryDataObject geomData, 
+            string name, 
+            long elementId, 
+            Preferences preferences)
         {
             int byteOffset = 0;
 
@@ -108,17 +114,17 @@
 
             byteOffset = GLTFBinaryDataUtils.ExportVertices(bufferIdx, byteOffset, geomData, bufferData, bufferViews, accessors, out int sizeOfVec3View, out int elementsPerVertex);
 
-            if (exportNormals)
+            if (preferences.normals)
             {
                 byteOffset = GLTFBinaryDataUtils.ExportNormals(bufferIdx, byteOffset, geomData, bufferData, bufferViews, accessors);
             }
 
-            if (geomData.Uvs != null && geomData.Uvs.Count > 0)
+            if (preferences.materials == MaterialsEnum.textures)
             {
                 byteOffset = GLTFBinaryDataUtils.ExportUVs(bufferIdx, byteOffset, geomData, bufferData, bufferViews, accessors);
             }
 
-            if (exportBatchId)
+            if (preferences.batchId)
             {
                 byteOffset = GLTFBinaryDataUtils.ExportBatchId(bufferIdx, byteOffset, sizeOfVec3View, elementsPerVertex, elementId, geomData, bufferData, bufferViews, accessors);
             }

--- a/Common_glTF_Exporter/Utils/glTFExportUtils.cs
+++ b/Common_glTF_Exporter/Utils/glTFExportUtils.cs
@@ -113,12 +113,19 @@
                 byteOffset = GLTFBinaryDataUtils.ExportNormals(bufferIdx, byteOffset, geomData, bufferData, bufferViews, accessors);
             }
 
+            if (geomData.Uvs != null && geomData.Uvs.Count > 0)
+            {
+                byteOffset = GLTFBinaryDataUtils.ExportUVs(bufferIdx, byteOffset, geomData, bufferData, bufferViews, accessors);
+            }
+
             if (exportBatchId)
             {
                 byteOffset = GLTFBinaryDataUtils.ExportBatchId(bufferIdx, byteOffset, sizeOfVec3View, elementsPerVertex, elementId, geomData, bufferData, bufferViews, accessors);
             }
 
             byteOffset = GLTFBinaryDataUtils.ExportFaces(bufferIdx, byteOffset, geomData, bufferData, bufferViews, accessors);
+
+            buffer.byteLength = byteOffset;
 
             return bufferData;
         }

--- a/Common_glTF_Exporter/Utils/glTFExportUtils.cs
+++ b/Common_glTF_Exporter/Utils/glTFExportUtils.cs
@@ -1,85 +1,85 @@
-﻿namespace Common_glTF_Exporter.Utils
-{
-    using System;
-    using System.Collections.Generic;
-    using System.Linq;
-    using Autodesk.Revit.DB;
-    using Common_glTF_Exporter.Core;
-    using Common_glTF_Exporter.Model;
-    using Common_glTF_Exporter.Windows.MainWindow;
-    using Revit_glTF_Exporter;
-
-    public class GLTFExportUtils
+﻿    namespace Common_glTF_Exporter.Utils
     {
-        const int DEF_COLOR = 250;
-        const string DEF_MATERIAL_NAME = "default";
+        using System;
+        using System.Collections.Generic;
+        using System.Linq;
+        using Autodesk.Revit.DB;
+        using Common_glTF_Exporter.Core;
+        using Common_glTF_Exporter.Model;
+        using Common_glTF_Exporter.Windows.MainWindow;
+        using Revit_glTF_Exporter;
 
-        public static GLTFMaterial GetGLTFMaterial(List<GLTFMaterial> gltfMaterials, Material material, bool doubleSided)
+        public class GLTFExportUtils
         {
-            // search for an already existing material
-            var m = gltfMaterials.FirstOrDefault(x =>
-            x.pbrMetallicRoughness.baseColorFactor[0] == material.Color.Red &&
-            x.pbrMetallicRoughness.baseColorFactor[1] == material.Color.Green &&
-            x.pbrMetallicRoughness.baseColorFactor[2] == material.Color.Blue && x.doubleSided == doubleSided);
+            const int DEF_COLOR = 250;
+            const string DEF_MATERIAL_NAME = "default";
 
-            return m != null ? m : GLTFExportUtils.CreateGLTFMaterial(DEF_MATERIAL_NAME, 0, new Color(DEF_COLOR, DEF_COLOR, DEF_COLOR), doubleSided);
-        }
-
-        public static GLTFMaterial CreateGLTFMaterial(string materialName, int materialOpacity, Color color, bool doubleSided)
-        {
-            // construct the material
-            GLTFMaterial gl_mat = new GLTFMaterial();
-            gl_mat.doubleSided = doubleSided;
-            float opacity = 1 - (float)materialOpacity;
-            gl_mat.name = materialName;
-            GLTFPBR pbr = new GLTFPBR();
-            pbr.baseColorFactor = new List<float>(4) { color.Red / 255f, color.Green / 255f, color.Blue / 255f, opacity };
-            pbr.metallicFactor = 0f;
-            pbr.roughnessFactor = 1f;
-            gl_mat.pbrMetallicRoughness = pbr;
-
-            return gl_mat;
-        }
-
-        public static void AddVerticesAndFaces(VertexLookupIntObject vertex, GeometryDataObject geometryDataObject, List<XYZ> pts)
-        {
-            var idx = vertex.AddVertex(new PointIntObject(pts[0]));
-            geometryDataObject.Faces.Add(idx);
-
-            var idx1 = vertex.AddVertex(new PointIntObject(pts[1]));
-            geometryDataObject.Faces.Add(idx1);
-
-            var idx2 = vertex.AddVertex(new PointIntObject(pts[2]));
-            geometryDataObject.Faces.Add(idx2);
-        }
-
-        const string UNDERSCORE = "_";
-
-        public static void AddOrUpdateCurrentItem(
-            Element element,
-            IndexedDictionary<GeometryDataObject> geomDataObj,
-            IndexedDictionary<VertexLookupIntObject> vertexIntObj,
-            IndexedDictionary<GLTFMaterial> materials)
-        {
-            // Add new "_current" entries if vertex_key is unique
-            string vertex_key = string.Concat(element.UniqueId, UNDERSCORE, materials.CurrentKey);
-            geomDataObj.AddOrUpdateCurrent(vertex_key, new GeometryDataObject());
-            vertexIntObj.AddOrUpdateCurrent(vertex_key, new VertexLookupIntObject());
-        }
-
-        public static void AddRPCNormals(Preferences preferences, MeshTriangle triangle, GeometryDataObject geomDataObj)
-        {
-            XYZ normal = GeometryUtils.GetNormal(triangle);
-
-            for (int j = 0; j < 3; j++)
+            public static GLTFMaterial GetGLTFMaterial(List<GLTFMaterial> gltfMaterials, Material material, bool doubleSided)
             {
-                geomDataObj.Normals.Add(normal.X);
-                geomDataObj.Normals.Add(normal.Y);
-                geomDataObj.Normals.Add(normal.Z);
-            }
-        }
+                // search for an already existing material
+                var m = gltfMaterials.FirstOrDefault(x =>
+                x.pbrMetallicRoughness.baseColorFactor[0] == material.Color.Red &&
+                x.pbrMetallicRoughness.baseColorFactor[1] == material.Color.Green &&
+                x.pbrMetallicRoughness.baseColorFactor[2] == material.Color.Blue && x.doubleSided == doubleSided);
 
-        const string BIN = ".bin";
+                return m != null ? m : GLTFExportUtils.CreateGLTFMaterial(DEF_MATERIAL_NAME, 0, new Color(DEF_COLOR, DEF_COLOR, DEF_COLOR), doubleSided);
+            }
+
+            public static GLTFMaterial CreateGLTFMaterial(string materialName, int materialOpacity, Color color, bool doubleSided)
+            {
+                // construct the material
+                GLTFMaterial gl_mat = new GLTFMaterial();
+                gl_mat.doubleSided = doubleSided;
+                float opacity = 1 - (float)materialOpacity;
+                gl_mat.name = materialName;
+                GLTFPBR pbr = new GLTFPBR();
+                pbr.baseColorFactor = new List<float>(4) { color.Red / 255f, color.Green / 255f, color.Blue / 255f, opacity };
+                pbr.metallicFactor = 0f;
+                pbr.roughnessFactor = 1f;
+                gl_mat.pbrMetallicRoughness = pbr;
+
+                return gl_mat;
+            }
+
+            public static void AddVerticesAndFaces(VertexLookupIntObject vertex, GeometryDataObject geometryDataObject, List<XYZ> pts)
+            {
+                var idx = vertex.AddVertex(new PointIntObject(pts[0]));
+                geometryDataObject.Faces.Add(idx);
+
+                var idx1 = vertex.AddVertex(new PointIntObject(pts[1]));
+                geometryDataObject.Faces.Add(idx1);
+
+                var idx2 = vertex.AddVertex(new PointIntObject(pts[2]));
+                geometryDataObject.Faces.Add(idx2);
+            }
+
+            const string UNDERSCORE = "_";
+
+            public static void AddOrUpdateCurrentItem(
+                Element element,
+                IndexedDictionary<GeometryDataObject> geomDataObj,
+                IndexedDictionary<VertexLookupIntObject> vertexIntObj,
+                IndexedDictionary<GLTFMaterial> materials)
+            {
+                // Add new "_current" entries if vertex_key is unique
+                string vertex_key = string.Concat(element.UniqueId, UNDERSCORE, materials.CurrentKey);
+                geomDataObj.AddOrUpdateCurrent(vertex_key, new GeometryDataObject());
+                vertexIntObj.AddOrUpdateCurrent(vertex_key, new VertexLookupIntObject());
+            }
+
+            public static void AddRPCNormals(Preferences preferences, MeshTriangle triangle, GeometryDataObject geomDataObj)
+            {
+                XYZ normal = GeometryUtils.GetNormal(triangle);
+
+                for (int j = 0; j < 3; j++)
+                {
+                    geomDataObj.Normals.Add(normal.X);
+                    geomDataObj.Normals.Add(normal.Y);
+                    geomDataObj.Normals.Add(normal.Z);
+                }
+            }
+
+            const string BIN = ".bin";
 
         /// <summary>
         /// Takes the intermediate geometry data and performs the calculations
@@ -94,14 +94,19 @@
         /// <param name="exportBatchId">exportBatchId.</param>
         /// <param name="exportNormals">exportNormals.</param>
         /// <returns>Returns the GLTFBinaryData object.</returns>
-        public static GLTFBinaryData AddGeometryMeta(List<GLTFBuffer> buffers, 
-            List<GLTFAccessor> accessors, 
-            List<GLTFBufferView> bufferViews, 
-            GeometryDataObject geomData, 
-            string name, 
-            long elementId, 
-            Preferences preferences)
+        public static GLTFBinaryData AddGeometryMeta(
+                List<GLTFBuffer> buffers,
+                List<GLTFAccessor> accessors,
+                List<GLTFBufferView> bufferViews,
+                GeometryDataObject geomData,
+                string name,
+                long elementId,
+                Preferences preferences,
+                GLTFMaterial material,
+                List<GLTFImage> images,
+                List<GLTFTexture> textures)
         {
+
             int byteOffset = 0;
 
             // add a buffer
@@ -112,16 +117,20 @@
             GLTFBinaryData bufferData = new GLTFBinaryData();
             bufferData.name = buffer.uri;
 
+
             byteOffset = GLTFBinaryDataUtils.ExportVertices(bufferIdx, byteOffset, geomData, bufferData, bufferViews, accessors, out int sizeOfVec3View, out int elementsPerVertex);
 
             if (preferences.normals)
             {
                 byteOffset = GLTFBinaryDataUtils.ExportNormals(bufferIdx, byteOffset, geomData, bufferData, bufferViews, accessors);
-            }
+            }  
 
-            if (preferences.materials == MaterialsEnum.textures)
+            if (preferences.materials == MaterialsEnum.textures &&
+                material.pbrMetallicRoughness?.baseColorTexture != null)
             {
+                byteOffset = GLTFBinaryDataUtils.ExportImageBuffer(bufferIdx, byteOffset, material, images, textures, bufferData, bufferViews);
                 byteOffset = GLTFBinaryDataUtils.ExportUVs(bufferIdx, byteOffset, geomData, bufferData, bufferViews, accessors);
+                
             }
 
             if (preferences.batchId)
@@ -131,73 +140,74 @@
 
             byteOffset = GLTFBinaryDataUtils.ExportFaces(bufferIdx, byteOffset, geomData, bufferData, bufferViews, accessors);
 
-            buffer.byteLength = byteOffset;
+            buffers[bufferIdx].byteLength = byteOffset;
 
             return bufferData;
         }
 
+
         public static void AddNormals(Transform transform, PolymeshTopology polymesh, List<double> normals)
-        {
-            IList<XYZ> polymeshNormals = polymesh.GetNormals();
-
-            switch (polymesh.DistributionOfNormals)
             {
-                case DistributionOfNormals.AtEachPoint:
-                {
-                    foreach (PolymeshFacet facet in polymesh.GetFacets())
-                    {
-                        List<XYZ> normalPoints = new List<XYZ>
-                        {
-                            transform.OfVector(polymeshNormals[facet.V1]).Normalize(),
-                            transform.OfVector(polymeshNormals[facet.V2]).Normalize(),
-                            transform.OfVector(polymeshNormals[facet.V3]).Normalize(),
-                        };
+                IList<XYZ> polymeshNormals = polymesh.GetNormals();
 
-                        foreach (var normalPoint in normalPoints)
+                switch (polymesh.DistributionOfNormals)
+                {
+                    case DistributionOfNormals.AtEachPoint:
+                    {
+                        foreach (PolymeshFacet facet in polymesh.GetFacets())
                         {
-                            normals.Add(normalPoint.X);
-                            normals.Add(normalPoint.Y);
-                            normals.Add(normalPoint.Z);
+                            List<XYZ> normalPoints = new List<XYZ>
+                            {
+                                transform.OfVector(polymeshNormals[facet.V1]).Normalize(),
+                                transform.OfVector(polymeshNormals[facet.V2]).Normalize(),
+                                transform.OfVector(polymeshNormals[facet.V3]).Normalize(),
+                            };
+
+                            foreach (var normalPoint in normalPoints)
+                            {
+                                normals.Add(normalPoint.X);
+                                normals.Add(normalPoint.Y);
+                                normals.Add(normalPoint.Z);
+                            }
                         }
+
+                        break;
                     }
 
-                    break;
-                }
-
-                case DistributionOfNormals.OnePerFace:
-                {
-                    foreach (var facet in polymesh.GetFacets())
+                    case DistributionOfNormals.OnePerFace:
                     {
-                        foreach (var normal in polymesh.GetNormals())
+                        foreach (var facet in polymesh.GetFacets())
+                        {
+                            foreach (var normal in polymesh.GetNormals())
+                            {
+                                var newNormal = transform.OfVector(normal).Normalize();
+
+                                for (int j = 0; j < 3; j++)
+                                {
+                                    normals.Add(newNormal.X);
+                                    normals.Add(newNormal.Y);
+                                    normals.Add(newNormal.Z);
+                                }
+                            }
+                        }
+
+                        break;
+                    }
+
+                    case DistributionOfNormals.OnEachFacet:
+                    {
+                        foreach (XYZ normal in polymeshNormals)
                         {
                             var newNormal = transform.OfVector(normal).Normalize();
 
-                            for (int j = 0; j < 3; j++)
-                            {
-                                normals.Add(newNormal.X);
-                                normals.Add(newNormal.Y);
-                                normals.Add(newNormal.Z);
-                            }
+                            normals.Add(newNormal.X);
+                            normals.Add(newNormal.Y);
+                            normals.Add(newNormal.Z);
                         }
+
+                        break;
                     }
-
-                    break;
-                }
-
-                case DistributionOfNormals.OnEachFacet:
-                {
-                    foreach (XYZ normal in polymeshNormals)
-                    {
-                        var newNormal = transform.OfVector(normal).Normalize();
-
-                        normals.Add(newNormal.X);
-                        normals.Add(newNormal.Y);
-                        normals.Add(newNormal.Z);
-                    }
-
-                    break;
                 }
             }
         }
     }
-}

--- a/Common_glTF_Exporter/Utils/glTFExportUtils.cs
+++ b/Common_glTF_Exporter/Utils/glTFExportUtils.cs
@@ -56,13 +56,13 @@
         const string UNDERSCORE = "_";
 
         public static void AddOrUpdateCurrentItem(
-            IndexedDictionary<GLTFNode> nodes,
+            Element element,
             IndexedDictionary<GeometryDataObject> geomDataObj,
             IndexedDictionary<VertexLookupIntObject> vertexIntObj,
             IndexedDictionary<GLTFMaterial> materials)
         {
             // Add new "_current" entries if vertex_key is unique
-            string vertex_key = string.Concat(nodes.CurrentKey, UNDERSCORE, materials.CurrentKey);
+            string vertex_key = string.Concat(element.UniqueId, UNDERSCORE, materials.CurrentKey);
             geomDataObj.AddOrUpdateCurrent(vertex_key, new GeometryDataObject());
             vertexIntObj.AddOrUpdateCurrent(vertex_key, new VertexLookupIntObject());
         }

--- a/Common_glTF_Exporter/Windows/AboutUsWindow.xaml
+++ b/Common_glTF_Exporter/Windows/AboutUsWindow.xaml
@@ -7,7 +7,7 @@
              mc:Ignorable="d" 
              WindowStartupLocation="CenterScreen"
              Title="Exporting process in progress..." 
-             Height="408"
+             Height="428"
              Width="400"
              ResizeMode="NoResize"
              Topmost="True"
@@ -42,12 +42,7 @@
         </Border.Effect>
 
         <Grid
-              Background="Transparent" Margin="9,0,9,9">
-            <Grid.RowDefinitions>
-                <RowDefinition Height="3*"/>
-                <RowDefinition Height="40*"/>
-            </Grid.RowDefinitions>
-
+              Background="Transparent" Margin="20">
 
             <Button Style="{DynamicResource everseTitleButtonStyle}"
                     Background="Transparent" 
@@ -55,7 +50,7 @@
                     Click="everse_Link" 
                     HorizontalAlignment="Left"
                     VerticalAlignment="Top"
-                    Margin="10,13,0,0" Height="23" Width="136" Grid.RowSpan="2"  >
+                    Height="36" Width="200" Grid.RowSpan="2"  >
             </Button>
 
             <Line Stroke="{DynamicResource MainGray}"
@@ -63,7 +58,7 @@
                   Opacity="0.5"
                   StrokeThickness="4"
                   VerticalAlignment="Top"
-                  Margin="-9,27,-9,0" RenderTransformOrigin="0.5,0.5" Height="2" Grid.Row="1">
+                  Margin="-9,55,-9,0" RenderTransformOrigin="0.5,0.5" Height="2" Grid.Row="1">
                 <Line.RenderTransform>
                     <TransformGroup>
                         <ScaleTransform ScaleY="1"/>
@@ -77,13 +72,16 @@
 
             <Button
                     Style="{DynamicResource CloseButtonStyle}"
-                    Margin="98,231,0,0"
+                    Margin="98,261,0,0"
                     Background="Transparent"
                     Click="Title_Link"
                     FontWeight="Light"
                     FontSize="12"     
                     Foreground="{DynamicResource MainGray}"
-                    VerticalAlignment="Top" Height="28" HorizontalAlignment="Left" Width="132" Grid.Row="1">
+                    VerticalAlignment="Top" 
+                    Height="28" 
+                    HorizontalAlignment="Left" 
+                    Width="132">
                 <Button.Template>
                     <ControlTemplate TargetType="Button">
                         <Border x:Name="border"  Background="Transparent" Margin="0,0,3,0">
@@ -130,7 +128,8 @@
                    Style="{DynamicResource TabCloseButtonStyle}"
                    Name="CloseButton"  
                    Click="CancelProcess_Click" 
-                   VerticalAlignment="Top" Margin="0,13,13,0" Grid.RowSpan="2" HorizontalAlignment="Right" Width="20"/>
+                   HorizontalAlignment="Right"
+                   VerticalAlignment="Top" />
 
 
             <TextBlock
@@ -142,12 +141,15 @@
                         Width="332" 
                         Height="136" 
                         VerticalAlignment="Top" 
-                        RenderTransformOrigin="0.16,0.487" Margin="10,50,0,0" Grid.Row="1"><Run Text="We are architects and engineers who code with a vision to improve how humans interact with buildings. "/><LineBreak/><Run/><LineBreak/><Run Text="We do this through digital transformation and innovative solutions, rethinking existing products and processes in our space."/><LineBreak/><Run/><LineBreak/><Run Text="Let's build something amazing together"/><Run Text="!"/></TextBlock>
+                        Margin="0,90,0,0" ><Run Text="We are architects and engineers who code with a vision to improve how humans interact with buildings. "/><LineBreak/><Run/><LineBreak/><Run Text="We do this through digital transformation and innovative solutions, rethinking existing products and processes in our space."/><LineBreak/><Run/><LineBreak/><Run Text="Let's build something amazing together"/><Run Text="!"/></TextBlock>
+            
             <Button Content="Cancel" 
                     Style="{DynamicResource MainButtonStyle}"
                     Width="128"
-                    Margin="106,295,0,0"
-                    Click="CancelProcess_Click" Height="20" VerticalAlignment="Top" HorizontalAlignment="Left" Grid.Row="1"/>
+                    Click="CancelProcess_Click"
+                    Height="20" 
+                    VerticalAlignment="Bottom" 
+                    HorizontalAlignment="Center"/>
         </Grid>
     </Border>
 

--- a/Common_glTF_Exporter/Windows/FeedbackWindow.xaml
+++ b/Common_glTF_Exporter/Windows/FeedbackWindow.xaml
@@ -7,8 +7,8 @@
              mc:Ignorable="d" 
              WindowStartupLocation="CenterScreen"
              Title="Exporting process in progress..." 
-             Height="266"
-             Width="337"
+             Height="335"
+             Width="357"
              ResizeMode="NoResize"
              Topmost="True"
              ShowInTaskbar="True"
@@ -25,7 +25,7 @@
         </Border.Effect>
 
         <Grid
-              Background="Transparent" Margin="9,0,9,9">
+              Background="Transparent" Margin="20">
             
             <Button Style="{DynamicResource MainTitleButtonStyle}"
                     Background="Transparent" 
@@ -33,7 +33,7 @@
                     Click="Leia_Link" 
                     HorizontalAlignment="Left"
                     VerticalAlignment="Top"
-                    Margin="10,10,0,0" Height="44" Width="149"  >
+                    Margin="0,0,0,0" Height="44" Width="149"  >
             </Button>
 
             <Line Stroke="{DynamicResource MainGray}"
@@ -41,7 +41,7 @@
                   Opacity="0.5"
                   StrokeThickness="4"
                   VerticalAlignment="Top"
-                  Margin="-9,59,-9,0" RenderTransformOrigin="0.5,0.5" Height="2">
+                  Margin="-9,55,-9,0" RenderTransformOrigin="0.5,0.5" Height="2">
                 <Line.RenderTransform>
                     <TransformGroup>
                         <ScaleTransform ScaleY="1"/>
@@ -55,24 +55,25 @@
 
             <Button
                     Style="{DynamicResource CloseButtonStyle}"
-                    Margin="76,128,89,0"
+                    Margin="0,150,0,0"
                     Background="Transparent"
                     Click="Title_Link"
                     FontWeight="Light"
-                    FontSize="12"     
+                    FontSize="12"
+                    HorizontalAlignment="Center"
                     Foreground="{DynamicResource MainGray}"
                     VerticalAlignment="Top" Height="26">
                 <Button.Template>
                     <ControlTemplate TargetType="Button">
                         <Border x:Name="border"  Background="Transparent" Margin="0,0,3,0">
-                            <Grid Margin="0,0,0,-4">
+                            <Grid Margin="0,0,0,-6">
                                 <Grid.ColumnDefinitions>
                                     <ColumnDefinition Width="243*"/>
                                     <ColumnDefinition Width="47*"/>
                                 </Grid.ColumnDefinitions>
                                 <TextBlock
                                     Text="Drop us a line" 
-                                    Margin="31,0,11,13"
+                                    Margin="0,0,0,13"
                                     FontWeight="Bold" Grid.ColumnSpan="2">
                                 </TextBlock>
                                 <Path
@@ -81,7 +82,7 @@
                           Stretch="Fill"
                           Stroke="{DynamicResource MainGray}"
                           StrokeThickness="1" 
-                          Margin="31,0,0,0" 
+                          Margin="0,0,0,0" 
                           Width="78" 
                           HorizontalAlignment="Left" 
                           VerticalAlignment="Bottom" 
@@ -108,7 +109,8 @@
                    Style="{DynamicResource TabCloseButtonStyle}"
                    Name="CloseButton"  
                    Click="CancelProcess_Click" 
-                   VerticalAlignment="Top" Margin="259,21,10,0"/>
+                   HorizontalAlignment="Right"
+                   VerticalAlignment="Top"/>
 
 
             <TextBlock
@@ -118,7 +120,7 @@
                         Foreground="{DynamicResource MainGray}" 
                         HorizontalAlignment="Center" 
                         Width="222" 
-                        Margin="0,71,0,0" 
+                        Margin="0,91,0,0" 
                         Height="18" 
                         VerticalAlignment="Top" 
                         RenderTransformOrigin="0.16,0.487"/>
@@ -131,12 +133,14 @@
                         Width="222" 
                         Height="18" 
                         VerticalAlignment="Top" 
-                        RenderTransformOrigin="0.16,0.487" Margin="0,89,0,0"/>
+                        RenderTransformOrigin="0.16,0.487" Margin="0,109,0,0"/>
+            
             <Button Content="Cancel" 
                     Style="{DynamicResource MainButtonStyle}"
                     Width="129"
-                    Margin="80,179,80,0"
-                    Click="CancelProcess_Click" Height="20" VerticalAlignment="Top"/>
+                    Click="CancelProcess_Click" 
+                    HorizontalAlignment="Center"
+                    VerticalAlignment="Bottom"/>
         </Grid>
     </Border>
 

--- a/Common_glTF_Exporter/Windows/MainWindow.xaml
+++ b/Common_glTF_Exporter/Windows/MainWindow.xaml
@@ -11,7 +11,7 @@
              Background="{x:Null}"
              mc:Ignorable="d" 
              Width="350" 
-             Height="760"
+             Height="770"
              Title="glTF Exporter Settings"
              ResizeMode="NoResize"
              Topmost="True"
@@ -90,7 +90,9 @@
                   Opacity="0.5"
                   StrokeThickness="4"
                   VerticalAlignment="Top"
-                  Margin="-9,55,-9,0" RenderTransformOrigin="0.5,0.5" Height="2">
+                  Margin="-9,55,-9,0" 
+                  RenderTransformOrigin="0.5,0.5" 
+                  Height="2">
                 <Line.RenderTransform>
                     <TransformGroup>
                         <ScaleTransform ScaleY="1"/>
@@ -338,10 +340,10 @@
 
             <Button Content="Export" 
                     Style="{DynamicResource MainButtonStyle}"
-                    Margin="0,580,0,0"
+                    Margin="0,00,0,50"
                     Click="OnExportView"
                     Width="152"
-                    VerticalAlignment="Top"
+                    VerticalAlignment="Bottom"
                     HorizontalAlignment="Center"/>
 
             <Button Style="{DynamicResource CloseButtonStyle}"

--- a/Common_glTF_Exporter/Windows/MainWindow.xaml
+++ b/Common_glTF_Exporter/Windows/MainWindow.xaml
@@ -209,17 +209,17 @@
                         HorizontalAlignment="Left" 
                         VerticalAlignment="Top">
                     
-                    <RadioButton x:Name="Textures" 
+                    <RadioButton x:Name="textures" 
                              Content="Textures" 
                              Click="RadioButtonMaterialsClick" 
                              Margin="{DynamicResource RadioButtonMargin}"/>
                     
-                    <RadioButton x:Name="Materials" 
+                    <RadioButton x:Name="materials" 
                              Content="Materials" 
                              Click="RadioButtonMaterialsClick" 
                              Margin="{DynamicResource RadioButtonMargin}"/>
                     
-                    <RadioButton x:Name="NoMaterials" 
+                    <RadioButton x:Name="nonematerials" 
                              Content="None" 
                              Click="RadioButtonMaterialsClick"/>
 
@@ -335,21 +335,26 @@
                         Margin="{DynamicResource DefaultMargin}"
                         HorizontalAlignment="Left" 
                         VerticalAlignment="Top">
+                    
                     <RadioButton x:Name="None" 
                              Content="None" 
                              Click="RadioButtonClick" 
                              Margin="{DynamicResource RadioButtonMargin}"/>
+                    
                     <RadioButton x:Name="ZIP" 
                              Content="ZIP" 
                              Click="RadioButtonClick" 
                              Margin="{DynamicResource RadioButtonMargin}"/>
+                    
                     <RadioButton x:Name="Draco" 
                              Content="Draco" 
                              Click="RadioButtonClick" 
                              Margin="{DynamicResource RadioButtonMargin}"/>
+                    
                     <RadioButton x:Name="Meshopt" 
                              Content="MeshOpt" 
                              Click="RadioButtonClick"/>
+                    
                 </StackPanel>
 
             </StackPanel>

--- a/Common_glTF_Exporter/Windows/MainWindow.xaml
+++ b/Common_glTF_Exporter/Windows/MainWindow.xaml
@@ -10,8 +10,8 @@
              AllowsTransparency="True"
              Background="{x:Null}"
              mc:Ignorable="d" 
-             Width="350" 
-             Height="770"
+             Width="380" 
+             Height="870"
              Title="glTF Exporter Settings"
              ResizeMode="NoResize"
              Topmost="True"
@@ -103,239 +103,255 @@
                 </Line.RenderTransform>
             </Line>
 
+            <StackPanel Orientation="Vertical" 
+             Margin="0,70,0,0" 
+             HorizontalAlignment="Left" 
+             VerticalAlignment="Top">
 
-            <Label  
+                <!--Format Section-->
+                <Label  
                     Style="{DynamicResource TitleLabels}"
-                    HorizontalAlignment="Left" 
-                    Margin="0,74,0,0" 
-                    VerticalAlignment="Top"
+                    Margin="{DynamicResource DefaultMargin}"
                     Content="Format"/>
 
-            <Grid>
-                <RadioButton x:Name="gltf" 
-                                 Grid.Column="0" 
+                <StackPanel Orientation="Horizontal" 
+                        Margin="{DynamicResource DefaultMargin}">
+
+                    <RadioButton x:Name="gltf" 
                                  Content="glTF" 
-                                 HorizontalAlignment="Left" 
-                                 Margin="0,117,0,0"
-                                 Click="RadioButtonFormatClick" 
-                                 RenderTransformOrigin="0.5,0.5" 
-                                 Height="14" 
-                                 VerticalAlignment="Top">
-                </RadioButton>
-                <RadioButton x:Name="glb" 
+                                 Click="RadioButtonFormatClick"
+                                 Margin="{DynamicResource RadioButtonMargin}">
+                    </RadioButton>
+
+                    <RadioButton x:Name="glb" 
                                  Content="glb" 
-                                 HorizontalAlignment="Left" 
-                                 Margin="90,117,0,0"
-                                 Click="RadioButtonFormatClick" 
-                                 RenderTransformOrigin="0.15,0.625" 
-                                 Width="60" 
-                                 Height="14" 
-                                 VerticalAlignment="Top"/>
-            </Grid>
+                                 Click="RadioButtonFormatClick"/>
+                </StackPanel>
 
-            <Line Style="{DynamicResource DashedLine}"
-                  Margin="0,148,0,0"/>
+                <Line Style="{DynamicResource DashedLine}"
+                      Margin="{DynamicResource LinesMargin}"/>
 
-            <Label   
-                    Style="{DynamicResource TitleLabels}"      
-                    HorizontalAlignment="Left" 
-                    Margin="0,152,0,0" 
-                    VerticalAlignment="Top"
-                    Content="Visualization"/>
+                <!--Visualization Section-->
+                <Label Style="{DynamicResource TitleLabels}"      
+                       Margin="{DynamicResource DefaultMargin}"
+                       Content="Transform"/>
 
+                <StackPanel Orientation="Horizontal" 
+                            Margin="{DynamicResource DefaultMargin}"
+                            HorizontalAlignment="Left" 
+                            VerticalAlignment="Top">
 
-            <ToggleButton
-              x:Name="materials"
-              Margin="0,199,0,0"
-              Style="{DynamicResource SwitchTypeToggleButton}" 
-              VerticalAlignment="Top"
-              HorizontalAlignment="Left"
-              Click="TrueFalseToggles"
-              ToolTip="Add or remove materiales from export">
-            </ToggleButton>
+                    <!--<ToggleButton x:Name="materials"
+                                  Margin="0,0,0,0"
+                                  Style="{DynamicResource SwitchTypeToggleButton}" 
+                                  Click="TrueFalseToggles"
+                                  ToolTip="Add or remove materiales from export"/>
 
-            <Label
-                Style="{DynamicResource SecondaryLabel}"
-                HorizontalAlignment="Left" 
-                Margin="53,191,0,0" 
-                VerticalAlignment="Top"
-                Content="Export Materials" 
-                Width="96"/>
+                    <Label Style="{DynamicResource SecondaryLabel}"
+                           HorizontalAlignment="Left" 
+                           Margin="{DynamicResource SeparationToggles}"
+                           VerticalAlignment="Top"
+                           Content="Export Materials" 
+                           Width="{DynamicResource SeparationOptionToggle}"/>-->
 
-            <ToggleButton
-                x:Name="flipAxis"
-                Margin="166,199,0,0"
-                Style="{DynamicResource SwitchTypeToggleButton}" 
-                VerticalAlignment="Top"
-                HorizontalAlignment="Left"
-                Click="TrueFalseToggles"
-                ToolTip="Rotate axis of the model 90 degress"/>
+                    <ToggleButton x:Name="flipAxis"
+                                  Margin="0,0,0,0"
+                                  Style="{DynamicResource SwitchTypeToggleButton}" 
+                                  Click="TrueFalseToggles"      
+                                  ToolTip="Rotate axis of the model 90 degress"/>
 
-            <Label  
-                    Style="{DynamicResource SecondaryLabel}"
-                    HorizontalAlignment="Left" 
-                    Margin="210,191,0,0" 
-                    VerticalAlignment="Top"
-                    Content="Flip YZ-Axys" 
-                    Width="86"/>
-            
-            <ToggleButton
-                x:Name="normals"
-                Margin="0,230,0,0"
-                Style="{DynamicResource SwitchTypeToggleButton}" 
-                VerticalAlignment="Top"
-                HorizontalAlignment="Left"
-                Click="TrueFalseToggles"
-                ToolTip="Export mesh normals"/>
-            
-            <Label  Style="{DynamicResource SecondaryLabel}"
-                    HorizontalAlignment="Left" 
-                    Margin="53,222,0,0"  
-                    VerticalAlignment="Top"
-                    Content="Export Normals" 
-                    Width="96"/>
-            
-            <ToggleButton
-                x:Name="relocateTo0"
-                Margin="166,230,0,0"
-                Style="{DynamicResource SwitchTypeToggleButton}" 
-                VerticalAlignment="Top"
-                HorizontalAlignment="Left"
-                Click="TrueFalseToggles"
-                ToolTip="Move the center of the model to 0,0,0"/>
-            
-            <Label  Style="{DynamicResource SecondaryLabel}"
-                    HorizontalAlignment="Left" 
-                    Margin="210,222,0,0" 
-                    VerticalAlignment="Top"
-                    Content="Relocate to 0" 
-                    Width="86"/>
-            
-            <ComboBox  x:Name="units" 
-                       ItemsSource="{Binding Units, UpdateSourceTrigger=PropertyChanged}" 
-                       SelectedItem="{Binding SelectedUnit, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" 
-                       DisplayMemberPath="Label" 
-                       Margin="77,311,17,0" 
-                       Height="30" 
-                       VerticalAlignment="Top"/>
-            <Label         
-                    Style="{DynamicResource TitleLabels}"
-                    HorizontalAlignment="Left" 
-                    Margin="0,276,0,0" 
-                    VerticalAlignment="Top"
-                    Content="Units"/>
-            
-            <Line Style="{DynamicResource DashedLine}"
-                  Margin="0,270,0,0"/>
-            
-            <Label      
-                        Style="{DynamicResource SecondaryLabel}"
+                    <Label  Style="{DynamicResource SecondaryLabel}"
+                            HorizontalAlignment="Left" 
+                            Margin="{DynamicResource SeparationToggles}"
+                            VerticalAlignment="Top"
+                            Content="Flip YZ-Axys"/>
+
+                </StackPanel>
+
+                <StackPanel Orientation="Horizontal" 
+                            Margin="{DynamicResource DefaultMargin}"
+                            HorizontalAlignment="Left" 
+                            VerticalAlignment="Top">
+
+                    <ToggleButton x:Name="normals"
+                                Margin="0,0,0,0"
+                                Style="{DynamicResource SwitchTypeToggleButton}" 
+                                Click="TrueFalseToggles"
+                                ToolTip="Export mesh normals"/>
+
+                    <Label  Style="{DynamicResource SecondaryLabel}"
+                            Margin="{DynamicResource SeparationToggles}" 
+                            Content="Export Normals" 
+                            Width="{DynamicResource SeparationOptionToggle}"/>
+
+                    <ToggleButton x:Name="relocateTo0"
+                                  Margin="0,0,0,0"
+                                  Style="{DynamicResource SwitchTypeToggleButton}" 
+                                  Click="TrueFalseToggles"
+                                  ToolTip="Move the center of the model to 0,0,0"/>
+
+                    <Label  Style="{DynamicResource SecondaryLabel}"
+                            Margin="{DynamicResource SeparationToggles}" 
+                            Content="Relocate to 0" 
+                            Width="86"/>
+
+                </StackPanel>
+
+                <Line Style="{DynamicResource DashedLine}"
+                      Margin="{DynamicResource LinesMargin}"/>
+
+                <Label Style="{DynamicResource TitleLabels}"      
+                       Margin="{DynamicResource DefaultMargin}"
+                       Content="Materials"/>
+
+                <StackPanel Orientation="Horizontal" 
+                        Margin="{DynamicResource DefaultMargin}"
                         HorizontalAlignment="Left" 
-                        Margin="0,314,0,0" 
-                        Content="Export unit:"
-                        VerticalAlignment="Top" >
-            </Label>
+                        VerticalAlignment="Top">
+                    
+                    <RadioButton x:Name="Textures" 
+                             Content="Textures" 
+                             Click="RadioButtonMaterialsClick" 
+                             Margin="{DynamicResource RadioButtonMargin}"/>
+                    
+                    <RadioButton x:Name="Materials" 
+                             Content="Materials" 
+                             Click="RadioButtonMaterialsClick" 
+                             Margin="{DynamicResource RadioButtonMargin}"/>
+                    
+                    <RadioButton x:Name="NoMaterials" 
+                             Content="None" 
+                             Click="RadioButtonMaterialsClick"/>
 
-            <Label         
+                </StackPanel>
+                
+
+                <Line Style="{DynamicResource DashedLine}"
+                      Margin="{DynamicResource LinesMargin}"/>
+                
+
+                <Label Style="{DynamicResource TitleLabels}"
+                       Margin="{DynamicResource DefaultMargin}"
+                       Content="Units"/>
+
+                <StackPanel Orientation="Horizontal" 
+                            Margin="{DynamicResource DefaultMargin}"
+                            HorizontalAlignment="Left" 
+                            VerticalAlignment="Top">
+
+                    <Label Style="{DynamicResource SecondaryLabel}"
+                           HorizontalAlignment="Left" 
+                           Margin="0,0,30,0" 
+                           Content="Export unit:"
+                           VerticalAlignment="Top" />
+
+                    <ComboBox  x:Name="units" 
+                               ItemsSource="{Binding Units, UpdateSourceTrigger=PropertyChanged}" 
+                               SelectedItem="{Binding SelectedUnit, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" 
+                               DisplayMemberPath="Label" 
+                               Height="28" 
+                               Width="180"/>
+
+                </StackPanel>
+
+                <Line Style="{DynamicResource DashedLine}"
+                      Margin="{DynamicResource LinesMargin}"/>
+
+                <Label         
                     Style="{DynamicResource TitleLabels}"
                     HorizontalAlignment="Left" 
-                    Margin="0,364,0,0" 
+                    Margin="{DynamicResource DefaultMargin}"
                     VerticalAlignment="Top"
                     Content="Data"
                     Width="46"/>
-            
-            <Line Style="{DynamicResource DashedLine}"
-                  Margin="0,360,0,0"/>
-            
-            <ToggleButton x:Name="levels"
-                          Margin="166,411,0,0"
-                          Style="{DynamicResource SwitchTypeToggleButton}" 
-                          VerticalAlignment="Top"
-                          HorizontalAlignment="Left"
-                          Click="TrueFalseToggles"
-                          ToolTip="Export Revit levels"/>
-            
-            <Label  Style="{DynamicResource SecondaryLabel}"
-                    HorizontalAlignment="Left" 
-                    Margin="210,405,0,0" 
-                    VerticalAlignment="Top"
-                    Content="Export Levels" 
-                    Width="96"/>
 
-            <ToggleButton x:Name="grids"
-                          Margin="166,442,0,0"
-                          Style="{DynamicResource SwitchTypeToggleButton}"
-                          VerticalAlignment="Top"
-                          HorizontalAlignment="Left"
-                          Click="TrueFalseToggles"
-                          ToolTip="Export Revit grids"/>
+                <StackPanel Orientation="Horizontal" 
+                            Margin="{DynamicResource DefaultMargin}" 
+                            HorizontalAlignment="Left" 
+                            VerticalAlignment="Top">
 
-            <Label Style="{DynamicResource SecondaryLabel}"
-                   HorizontalAlignment="Left" 
-                   Margin="210,436,0,0" 
-                   Height="24" 
-                   VerticalAlignment="Top"
-                   Content="Export Grids" 
-                   Width="96"/>
-            
-            <ToggleButton x:Name="batchId"
-                          Margin="0,411,0,0"
+                    <ToggleButton x:Name="batchId"
+                          Margin="0,0,0,0"
                           Style="{DynamicResource SwitchTypeToggleButton}" 
-                          HorizontalAlignment="Left"
-                          VerticalAlignment="Top"
                           Click="TrueFalseToggles"
                           ToolTip="Export Revit batchId"/>
-            
-            <Label  Style="{DynamicResource SecondaryLabel}"
-                    HorizontalAlignment="Left" 
-                    Margin="53,405,0,0" 
-                    VerticalAlignment="Top"
-                    Content="Export BatchId" 
-                    Width="96"/>
-            
-            <ToggleButton x:Name="properties"
-                          Margin="0,442,0,0"
-                          Style="{DynamicResource SwitchTypeToggleButton}" 
-                          VerticalAlignment="Top"
-                          HorizontalAlignment="Left"
-                          Click="TrueFalseToggles"
-                          ToolTip="Export all the properties from each element"/>
-            
-            <Label  Style="{DynamicResource SecondaryLabel}"
-                    HorizontalAlignment="Left" 
-                    Margin="53,436,0,0" 
-                    VerticalAlignment="Top"
-                    Content="Export Prop" 
-                    Width="68"/>
-            
-            <Label  Style="{DynamicResource TitleLabels}"
-                    HorizontalAlignment="Left" 
-                    Margin="0,482,0,0" 
-                    VerticalAlignment="Top"
-                    Content="Compression" />
 
-            <Line Style="{DynamicResource DashedLine}"
-                  Margin="0,470,0,0"/>
+                    <Label  Style="{DynamicResource SecondaryLabel}"
+                            Margin="{DynamicResource SeparationToggles}"
+                            Content="Export BatchId" 
+                            Width="{DynamicResource SeparationOptionToggle}"/>
 
-            <StackPanel Orientation="Horizontal" 
-                        Margin="0,527,0,0" 
+                    <ToggleButton x:Name="levels"
+                                  Margin="0,0,0,0"
+                                  Style="{DynamicResource SwitchTypeToggleButton}" 
+                                  Click="TrueFalseToggles"
+                                  ToolTip="Export Revit levels"/>
+
+                    <Label  Style="{DynamicResource SecondaryLabel}"
+                            Margin="{DynamicResource SeparationToggles}"
+                            Content="Export Levels" 
+                            Width="96"/>
+
+                </StackPanel>
+
+                <StackPanel Orientation="Horizontal" 
+                            Margin="{DynamicResource DefaultMargin}" 
+                            HorizontalAlignment="Left" 
+                            VerticalAlignment="Top">
+
+                    <ToggleButton x:Name="properties"
+                            Margin="0,0,0,0"
+                            Style="{DynamicResource SwitchTypeToggleButton}" 
+                            Click="TrueFalseToggles"
+                            ToolTip="Export all the properties from each element"/>
+
+                    <Label  Style="{DynamicResource SecondaryLabel}"
+                            Margin="{DynamicResource SeparationToggles}"
+                            Content="Export Prop" 
+                            Width="{DynamicResource SeparationOptionToggle}"/>
+
+                    <ToggleButton x:Name="grids"
+                                  Margin="0,0,0,0"
+                                  Style="{DynamicResource SwitchTypeToggleButton}"
+                                  Click="TrueFalseToggles"
+                                  ToolTip="Export Revit grids"/>
+
+                    <Label Style="{DynamicResource SecondaryLabel}"
+                           Margin="{DynamicResource SeparationToggles}"
+                           Height="24" 
+                           Content="Export Grids" 
+                           Width="96"/>
+
+                </StackPanel>
+
+                <Line Style="{DynamicResource DashedLine}"
+                      Margin="{DynamicResource LinesMargin}"/>
+
+                <Label  Style="{DynamicResource TitleLabels}"
+                        Content="Compression" 
+                        Margin="{DynamicResource DefaultMargin}"/>
+
+                <StackPanel Orientation="Horizontal" 
+                        Margin="{DynamicResource DefaultMargin}"
                         HorizontalAlignment="Left" 
                         VerticalAlignment="Top">
-                <RadioButton x:Name="None" 
+                    <RadioButton x:Name="None" 
                              Content="None" 
                              Click="RadioButtonClick" 
-                             Margin="0,0,30,0"/>
-                <RadioButton x:Name="ZIP" 
+                             Margin="{DynamicResource RadioButtonMargin}"/>
+                    <RadioButton x:Name="ZIP" 
                              Content="ZIP" 
                              Click="RadioButtonClick" 
-                             Margin="0,0,30,0"/>
-                <RadioButton x:Name="Draco" 
+                             Margin="{DynamicResource RadioButtonMargin}"/>
+                    <RadioButton x:Name="Draco" 
                              Content="Draco" 
                              Click="RadioButtonClick" 
-                             Margin="0,0,30,0"/>
-                <RadioButton x:Name="Meshopt" 
+                             Margin="{DynamicResource RadioButtonMargin}"/>
+                    <RadioButton x:Name="Meshopt" 
                              Content="MeshOpt" 
                              Click="RadioButtonClick"/>
+                </StackPanel>
+
             </StackPanel>
 
             <Button Content="Export" 

--- a/Common_glTF_Exporter/Windows/MainWindow.xaml.cs
+++ b/Common_glTF_Exporter/Windows/MainWindow.xaml.cs
@@ -12,6 +12,7 @@
     using Autodesk.Revit.DB;
     using Autodesk.Revit.UI;
     using Common_glTF_Exporter;
+    using Common_glTF_Exporter.Core;
     using Common_glTF_Exporter.Utils;
     using Common_glTF_Exporter.ViewModel;
     using Common_glTF_Exporter.Windows.MainWindow;
@@ -142,6 +143,14 @@
             SettingsConfig.SetValue(key, value);
         }
 
+        private void RadioButtonMaterialsClick(object sender, RoutedEventArgs e)
+        {
+            System.Windows.Controls.RadioButton button = sender as System.Windows.Controls.RadioButton;
+            string value = button.Name;
+            string key = "materials";
+            SettingsConfig.SetValue(key, value);
+        }
+        
         private void RadioButtonFormatClick(object sender, RoutedEventArgs e)
         {
             System.Windows.Controls.RadioButton button = sender as System.Windows.Controls.RadioButton;

--- a/Common_glTF_Exporter/Windows/MainWindow.xaml.cs
+++ b/Common_glTF_Exporter/Windows/MainWindow.xaml.cs
@@ -25,13 +25,14 @@
     /// 
     public partial class MainWindow : Window
     {
+        private Document doc;
 
-
-    public MainWindow(Document doc, View view)
+        public MainWindow(View view)
         {
             this.UnitsViewModel = new UnitsViewModel();
             this.DataContext = this.UnitsViewModel;
             MainView = this;
+            doc = ExternalApplication.RevitCollectorService.GetDocument();
 
             this.InitializeComponent();
 
@@ -70,7 +71,6 @@
             SettingsConfig.SetValue("path", directory);
             SettingsConfig.SetValue("fileName", nameOnly);
 
-            Document doc = exportView.Document;
             List<Element> elementsInView = Collectors.AllVisibleElementsByView(doc, doc.ActiveView);
 
             bool isRFA = IsDocumentRFA.Check(doc);

--- a/Common_glTF_Exporter/Windows/MainWindow.xaml.cs
+++ b/Common_glTF_Exporter/Windows/MainWindow.xaml.cs
@@ -98,7 +98,7 @@
             #if REVIT2019
             exporter.Export(exportView);
             #else
-            exporter.Export(exportView as View);
+           exporter.Export(exportView as View);
             #endif
 
             Analytics.Send("exported", SettingsConfig.GetValue("format")).GetAwaiter();

--- a/Common_glTF_Exporter/Windows/MainWindow/Preferences.cs
+++ b/Common_glTF_Exporter/Windows/MainWindow/Preferences.cs
@@ -16,9 +16,16 @@
         glb,
     }
 
+    public enum MaterialsEnum
+    {
+        textures,
+        materials,
+        none
+    }
+
     public class Preferences
     {
-        public bool materials { get; set; }
+        public MaterialsEnum materials { get; set; }
 
         public FormatEnum format { get; set; }
 

--- a/Common_glTF_Exporter/Windows/MainWindow/Preferences.cs
+++ b/Common_glTF_Exporter/Windows/MainWindow/Preferences.cs
@@ -20,7 +20,7 @@
     {
         textures,
         materials,
-        none
+        nonematerials
     }
 
     public class Preferences

--- a/Common_glTF_Exporter/Windows/MainWindow/Settings.cs
+++ b/Common_glTF_Exporter/Windows/MainWindow/Settings.cs
@@ -30,6 +30,13 @@
                     preferenceType.GetProperty(propertyName).SetValue(preferences, unitStatus);
                 }
 
+                if (property.PropertyType == typeof(MaterialsEnum))
+                {
+                    string result = SettingsConfig.GetValue(propertyName).ToString();
+                    Enum.TryParse(result, out MaterialsEnum unitStatus);
+                    preferenceType.GetProperty(propertyName).SetValue(preferences, unitStatus);
+                }
+
                 if (property.PropertyType == typeof(FormatEnum))
                 {
                     string result = SettingsConfig.GetValue(propertyName).ToString();

--- a/Common_glTF_Exporter/Windows/MainWindow/UpdateForm.cs
+++ b/Common_glTF_Exporter/Windows/MainWindow/UpdateForm.cs
@@ -70,6 +70,14 @@
                     }
 
                     break;
+                case "MaterialsEnum":
+                    var radioButtonMaterials = controls.Values.OfType<System.Windows.Controls.RadioButton>().FirstOrDefault(t => t.Name.Equals(preferenceType.GetProperty(property.Name).GetValue(preferences).ToString()));
+                    if (radioButtonMaterials != null)
+                    {
+                        radioButtonMaterials.IsChecked = true;
+                    }
+
+                    break;
                 case "Int32":
                     var slider = controls[property.Name] as Slider;
                     if (slider != null)

--- a/Common_glTF_Exporter/Windows/ProgressBarWindow.xaml
+++ b/Common_glTF_Exporter/Windows/ProgressBarWindow.xaml
@@ -7,7 +7,7 @@
              mc:Ignorable="d" 
              WindowStartupLocation="CenterScreen"
              Title="Exporting process in progress..." 
-             Height="262"
+             Height="300"
              Width="308"
              ResizeMode="NoResize"
              Topmost="True"
@@ -15,7 +15,7 @@
              Style="{DynamicResource CustomWindowStyle}">
 
 
-    <Border Background="{DynamicResource BackgroundColor}"
+    <Border Background="{DynamicResource SecondaryBackgroundColor}"
             BorderBrush="Transparent" 
             BorderThickness="1,1,1,1" 
             CornerRadius="8,8,8,8"
@@ -24,7 +24,7 @@
             <DropShadowEffect BlurRadius="20" Color="Gray" Opacity="0.3" ShadowDepth="0" Direction="0"></DropShadowEffect>
         </Border.Effect>
 
-        <Grid Margin="0"
+        <Grid Margin="20"
               Background="Transparent">
 
             <Button Style="{DynamicResource MainTitleButtonStyle}"
@@ -33,7 +33,7 @@
                     Click="Leia_Link" 
                     HorizontalAlignment="Left"
                     VerticalAlignment="Top"
-                    Margin="10,10,0,0" Height="44" Width="149"  >
+                    Margin="0,0,0,0" Height="44" Width="149"  >
             </Button>
 
             <Line Stroke="{DynamicResource MainGray}"
@@ -41,7 +41,7 @@
                   Opacity="0.5"
                   StrokeThickness="4"
                   VerticalAlignment="Top"
-                  Margin="0,59,0,0" RenderTransformOrigin="0.5,0.5" Height="2">
+                  Margin="-9,55,-9,0" RenderTransformOrigin="0.5,0.5" Height="2">
                 <Line.RenderTransform>
                     <TransformGroup>
                         <ScaleTransform ScaleY="1"/>
@@ -66,8 +66,8 @@
                    Style="{DynamicResource TabCloseButtonStyle}"
                    Name="CloseButton"  
                    Click="CancelProcess_Click" 
-                   VerticalAlignment="Top" 
-                Margin="266,18,10,0"/>
+                   VerticalAlignment="Top"
+                   HorizontalAlignment="Right"/>
 
             <ProgressBar Style="{DynamicResource ProgressBarStyle}" 
                     Name="ProgressBar"
@@ -75,8 +75,10 @@
                     DataContext="{Binding ViewModel, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"                        
                     Maximum="{Binding Path=ProgressBarMax}"
                     Value="{Binding Path=ProgressBarGraphicValue}"
-                    Margin="30,144,32,0" 
-                    Height="11" 
+                    Margin="0,144,0,0" 
+                    Height="11"
+                         Width="200"
+                         HorizontalAlignment="Center"
                     VerticalAlignment="Top"/>
 
             <TextBlock DataContext="{Binding ViewModel, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
@@ -84,18 +86,19 @@
                        Text="{Binding Path=ProgressBarPercentage, StringFormat={}{0:0}%}" 
                        TextAlignment="Center"
                        Foreground="{DynamicResource MainGray}"  
-                       HorizontalAlignment="Left" 
+                       HorizontalAlignment="Center" 
                        Width="50" 
-                       Margin="126,119,0,0" 
+                       Margin="0,120,0,0" 
                        Height="18" 
                        VerticalAlignment="Top"/>
             
             <Button Content="{Binding Action, UpdateSourceTrigger=PropertyChanged}" 
                     DataContext="{Binding ViewModel, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
                     Style="{DynamicResource MainButtonStyle}"
-                    Margin="80,0,86,16"
-                    Click="CancelProcess_Click"  
-                    VerticalAlignment="Bottom"/>
+                    Click="CancelProcess_Click"
+                    HorizontalAlignment="Center"
+                    VerticalAlignment="Bottom"
+                    Width="150"/>
         </Grid>
     </Border>
 

--- a/Common_glTF_Exporter/Windows/ProgressBarWindow.xaml.cs
+++ b/Common_glTF_Exporter/Windows/ProgressBarWindow.xaml.cs
@@ -5,6 +5,7 @@
     using System.Windows.Input;
     using Common_glTF_Exporter.Utils;
     using Common_glTF_Exporter.ViewModel;
+    using Common_glTF_Exporter.Core;
 
     /// <summary>
     /// Progress Bar Window.

--- a/Common_glTF_Exporter/Windows/Resources.xaml
+++ b/Common_glTF_Exporter/Windows/Resources.xaml
@@ -15,6 +15,7 @@
 
     <SolidColorBrush x:Key="HoverGray" Color="#e8e8e8"/>
     <SolidColorBrush x:Key="BackgroundColor" Color="#e8e3df"/>
+    <SolidColorBrush x:Key="SecondaryBackgroundColor" Color="#e8e3df"/>
     <SolidColorBrush x:Key="WindowForeColor" Color="Transparent"/>
     
     <!--Main Colours-->
@@ -119,7 +120,7 @@
         <Setter Property="Background" Value="{StaticResource WindowButtonColor}"/>
         <Setter Property="ToolTipService.ShowDuration" Value="2000"/>
         <Setter Property="ToolTipService.InitialShowDelay" Value="1500"/>
-        <Setter Property="Height"  Value="20"/>
+        <Setter Property="Height"  Value="25"/>
     </Style>
 
 

--- a/Common_glTF_Exporter/Windows/Resources.xaml
+++ b/Common_glTF_Exporter/Windows/Resources.xaml
@@ -26,7 +26,14 @@
     <!--Corner Radius of small Elements-->
     <CornerRadius x:Key="borderRadius" BottomLeft="5" BottomRight="5" TopLeft="5" TopRight="5"/>
     <!--Corner Radius of Large Elements-->
-    
+
+    <Thickness x:Key="DefaultMargin">0,0,0,10</Thickness>
+    <Thickness x:Key="LinesMargin">0,10,0,10</Thickness>
+    <Thickness x:Key="RadioButtonMargin">0,0,35,0</Thickness>
+    <Thickness x:Key="SeparationToggles">15,0,0,0</Thickness>
+    <System:Double x:Key="SeparationOptionToggle">120</System:Double>
+
+
     <CornerRadius x:Key="borderRadiusLarge" BottomLeft="10" BottomRight="10" TopLeft="10" TopRight="10"/>
     <System:Double x:Key="SecondaryFontSize">12</System:Double>
     <System:Double x:Key="MainFontSize">15</System:Double>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for exporting textures and images in glTF exports, including UV coordinate handling and texture transforms.
  - Introduced a new "Materials" export option with selectable modes: Textures, Materials, or None.
  - Enhanced UI with a new "Materials" radio button group and improved layout for export options.
  - Added service integration for accessing the active Revit document automatically.

- **Improvements**
  - Expanded material export to include normal, occlusion, and emissive textures, as well as emissive factors.
  - Improved binary export logic to handle texture and image data.
  - Enhanced JSON serialization for glTF, including extensions and conditional property inclusion.
  - Updated color themes and UI resources for a more consistent appearance.

- **Bug Fixes**
  - Improved handling and serialization of nullable properties for glTF attributes.
  - Fixed layout and alignment issues in various windows for a more polished user interface.

- **Refactor**
  - Streamlined method signatures and logic for export-related classes to use unified preferences and new enum types.
  - Deferred certain export operations for improved data consistency and structure.

- **Chores**
  - Added new utility methods for UV and image data processing.
  - Updated and reorganized resource dictionaries and style definitions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->