### PR TITLE
Allow to Install When Closing Revit

### DIFF
--- a/Common_glTF_Exporter/ExternalApplication.cs
+++ b/Common_glTF_Exporter/ExternalApplication.cs
@@ -5,6 +5,7 @@
     using Autodesk.Windows;
     using Common_glTF_Exporter;
     using Common_glTF_Exporter.Service;
+    using Common_glTF_Exporter.Version;
     using System;
     using System.IO;
     using System.Linq;
@@ -25,6 +26,7 @@
         private static string pushButtonText = "Leia";
         private static string addInPath = typeof(ExternalApplication).Assembly.Location;
         private static string buttonIconsFolder = Path.GetDirectoryName(addInPath) + "\\Images\\";
+        public static string InstallerRoute;
 
         internal Document Document { get; set; }
         public static UIApplication UiApp { get; private set; }
@@ -57,6 +59,10 @@
         /// <returns>Result.</returns>
         public Result OnShutdown(UIControlledApplication application)
         {
+            if (!string.IsNullOrEmpty(InstallerRoute))
+            {
+                RunLocalFile.Action(InstallerRoute);
+            }
             return Result.Succeeded;
         }
 

--- a/Common_glTF_Exporter/Windows/VersionWindow.xaml
+++ b/Common_glTF_Exporter/Windows/VersionWindow.xaml
@@ -111,12 +111,31 @@
                 </Button.Template>
             </Button>
 
-            <Button Content="Update" 
+            <StackPanel Orientation="Horizontal"
+                        HorizontalAlignment="Center"
+                        VerticalAlignment="Bottom">
+
+                <Button Content="Update on Exit" 
+                Margin="10,0,10,13" 
+                Click="Button_UpdateOnExit" 
+                Height="30"
+                Width="100"
+                Background="Transparent"
+                Foreground="{DynamicResource WindowButtonColor}"
+                Style="{DynamicResource MainButtonStyle}"
+                VerticalAlignment="Bottom"/>
+
+                <Button Content="Update Now" 
                 Margin="10,0,10,13" 
                 Click="Button_ClickAsync" 
+                Width="100"
                 Height="30" 
                 Style="{DynamicResource MainButtonStyle}"
                 VerticalAlignment="Bottom"/>
+                
+            </StackPanel>
+            
+
         </Grid>
     </Border>
 

--- a/Common_glTF_Exporter/Windows/VersionWindow.xaml.cs
+++ b/Common_glTF_Exporter/Windows/VersionWindow.xaml.cs
@@ -30,17 +30,35 @@ namespace Revit_glTF_Exporter
         {
             this.Hide();
 
-            string tempPath = Path.GetTempPath();
-            string tempFolder = System.IO.Path.Combine(tempPath, "LeiaInstaller");
-            string versionFolder = System.IO.Path.Combine(tempFolder, _fileVersion);
-            DirectoryUtils.CreateDirectoryIfNotExists(versionFolder);
-            DirectoryUtils.DeleteFilesInDirectoyy(versionFolder);
+            string versionFolder = VersionFolder();
             await DownloadFile.FromServer(versionFolder, _installerName);
 
             string fileLocation = System.IO.Path.Combine(versionFolder, _installerName);;
             RunLocalFile.Action(fileLocation);
 
             Close();
+        }
+
+
+        private async void Button_UpdateOnExit(object sender, RoutedEventArgs e)
+        {
+            this.Hide();
+            string versionFolder = VersionFolder();
+            await DownloadFile.FromServer(versionFolder, _installerName);
+
+            string fileLocation = System.IO.Path.Combine(versionFolder, _installerName);
+            ExternalApplication.InstallerRoute = fileLocation;
+            Close();
+        }
+
+        private static string VersionFolder()
+        {
+            string tempPath = Path.GetTempPath();
+            string tempFolder = System.IO.Path.Combine(tempPath, "LeiaInstaller");
+            string versionFolder = System.IO.Path.Combine(tempFolder, _fileVersion);
+            DirectoryUtils.CreateDirectoryIfNotExists(versionFolder);
+            DirectoryUtils.DeleteFilesInDirectoyy(versionFolder);
+            return versionFolder;
         }
 
         private void Close_Click(object sender, RoutedEventArgs e)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added "Update on Exit" option alongside the existing "Update Now" button in the version window, allowing users to defer application updates until the next exit.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->