### PR TITLE
Fix Image Gamma Unsupported By glTF

### DIFF
--- a/Common_glTF_Exporter/Materials/BitmapsUtils.cs
+++ b/Common_glTF_Exporter/Materials/BitmapsUtils.cs
@@ -30,6 +30,28 @@ namespace Common_glTF_Exporter.Materials
             }
         }
 
+        /// <summary>
+        /// Removes non-default gamma or ICC profile metadata from a PNG/JPG file
+        /// by re-encoding it to a clean sRGB version in memory.
+        /// </summary>
+        /// <param name="path">Path to the source image</param>
+        /// <returns>Byte array of the cleaned image (PNG)</returns>
+        public static byte[] CleanGamma(string path, ImageFormat imageFormat)
+        {
+            using (var original = new Bitmap(path))
+            using (var ms = new MemoryStream())
+            {
+                // Convert to standard sRGB (System.Drawing assumes sRGB by default)
+                using (var converted = new Bitmap(original.Width, original.Height, PixelFormat.Format24bppRgb))
+                using (var g = Graphics.FromImage(converted))
+                {
+                    g.DrawImage(original, 0, 0, original.Width, original.Height);
+                    converted.Save(ms, imageFormat);
+                }
+                return ms.ToArray();
+            }
+        }
+
         public static byte[] BlendImageWithColor(
             byte[] imageBytes,
             double fade,

--- a/Common_glTF_Exporter/Utils/GLTFBinaryDataUtils.cs
+++ b/Common_glTF_Exporter/Utils/GLTFBinaryDataUtils.cs
@@ -211,9 +211,9 @@ namespace Common_glTF_Exporter.Utils
 
             if (material.pbrMetallicRoughness.baseColorTexture.index == -1)
             {
-                byte[] imageBytes = File.ReadAllBytes(material.EmbeddedTexturePath);
-                (string , ImageFormat) mimeType = BitmapsUtils.GetMimeType(material.EmbeddedTexturePath);
-
+                (string, ImageFormat) mimeType = BitmapsUtils.GetMimeType(material.EmbeddedTexturePath);
+                byte[] imageBytes = BitmapsUtils.CleanGamma(material.EmbeddedTexturePath, mimeType.Item2);
+               
                 byte[] blendedBytes = BitmapsUtils.BlendImageWithColor(imageBytes, material.Fadevalue, 
                     material.BaseColor, mimeType.Item2, material.TintColour);
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automatic gamma and ICC profile normalization to the image export process, ensuring cleaner, more consistent sRGB color representation across all exported textures and improved overall texture quality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->